### PR TITLE
Correct wording in RAML for 404 errors

### DIFF
--- a/resources/public/api/conf/1.0/broughtForwardLosses_amend.raml
+++ b/resources/public/api/conf/1.0/broughtForwardLosses_amend.raml
@@ -8,7 +8,7 @@ is:
   - errors.ruleLossAmount
   - errors.incorrectOrEmptyBody
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundLossId
   - errors.ruleNoChangeLossAmount
 displayName: Amend a Brought Forward Loss Amount [test only]
 description: This endpoint allows users to update an existing brought forward loss amount which they have previously populated.

--- a/resources/public/api/conf/1.0/broughtForwardLosses_create.raml
+++ b/resources/public/api/conf/1.0/broughtForwardLosses_create.raml
@@ -15,7 +15,7 @@ is:
   - errors.ruleLossAmount
   - errors.ruleDuplicateSubmission
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundIncomeSource
 displayName: Create a Brought Forward Loss [test only]
 description: This endpoint allows users to create a new brought forward loss which can be submitted against Self-employment, Self-employment class 4, UK FHL property and UK other (Non-FHL) property for the tax year prior to joining MTD.
 (annotations.sandboxData): !include scenarios/broughtForwardLosses_create.md

--- a/resources/public/api/conf/1.0/broughtForwardLosses_delete.raml
+++ b/resources/public/api/conf/1.0/broughtForwardLosses_delete.raml
@@ -5,7 +5,7 @@ is:
   - errors.formatNino
   - errors.formatLossId
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundLossId
   - errors.ruleDeleteAfterCrystallisation
 displayName: Delete a Brought Forward Loss [test only]
 description: This endpoint allows users to delete an existing brought forward loss. The user should be aware that where a loss has been used as part of a successful crystallisation activity, deletion will be blocked and an error code will be returned. In such a case, the user can amend the loss amount to zero. If the user wants to delete any details, they need to create a new account for that business.

--- a/resources/public/api/conf/1.0/broughtForwardLosses_get.raml
+++ b/resources/public/api/conf/1.0/broughtForwardLosses_get.raml
@@ -4,7 +4,7 @@ is:
   - errors.formatNino
   - errors.formatLossId
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundLossId
 displayName: Retrieve a Brought Forward Loss [test only]
 description: This endpoint allows a user to retrieve a single brought forward loss.
 (annotations.sandboxData): !include scenarios/broughtForwardLosses_get.md

--- a/resources/public/api/conf/1.0/broughtForwardLosses_list.raml
+++ b/resources/public/api/conf/1.0/broughtForwardLosses_list.raml
@@ -9,7 +9,7 @@ is:
   - errors.formatLossType
   - errors.formatSelfEmploymentId
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundNino
   - queryParameters.taxYearForBFLosses
   - queryParameters.typeOfLossForBFLosses
   - queryParameters.selfEmploymentId

--- a/resources/public/api/conf/1.0/errors.raml
+++ b/resources/public/api/conf/1.0/errors.raml
@@ -15,6 +15,46 @@ traits:
               description: The matching resource is not found.
               value:
                 code: MATCHING_RESOURCE_NOT_FOUND
+  notFoundIncomeSource:
+    responses:
+      404:
+        body:
+          application/json:
+            type: types.errorResponse
+            example:
+              description: The remote endpoint has indicated that the given income source could not be found
+              value:
+                code: MATCHING_RESOURCE_NOT_FOUND
+  notFoundNino:
+    responses:
+      404:
+        body:
+          application/json:
+            type: types.errorResponse
+            example:
+              description: The remote endpoint has indicated that no data can be found for the given NINO
+              value:
+                code: MATCHING_RESOURCE_NOT_FOUND
+  notFoundLossId:
+    responses:
+      404:
+        body:
+          application/json:
+            type: types.errorResponse
+            example:
+              description: The remote endpoint has indicated that no data can be found for the given loss ID
+              value:
+                code: MATCHING_RESOURCE_NOT_FOUND
+  notFoundClaimId:
+    responses:
+      404:
+        body:
+          application/json:
+            type: types.errorResponse
+            example:
+              description: The remote endpoint has indicated that no data can be found for the given claim ID
+              value:
+                code: MATCHING_RESOURCE_NOT_FOUND
   clientOrAgentNotAuthorised:
     responses:
       403:

--- a/resources/public/api/conf/1.0/lossClaims_amend.raml
+++ b/resources/public/api/conf/1.0/lossClaims_amend.raml
@@ -9,7 +9,7 @@ is:
   - errors.incorrectOrEmptyBody
   - errors.ruleTypeOfClaim403
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundClaimId
 displayName: Amend a Loss Claim [test only]
 description: This endpoint allows the user to change the type of claim for an existing loss claim.
 (annotations.sandboxData): !include scenarios/lossClaims_amend.md

--- a/resources/public/api/conf/1.0/lossClaims_create.raml
+++ b/resources/public/api/conf/1.0/lossClaims_create.raml
@@ -15,7 +15,7 @@ is:
   - errors.rulePeriodNotEnded
   - errors.ruleDuplicateClaimSubmission
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundIncomeSource
   - errors.ruleAccountingPeriodNotActive
 displayName: Create a Loss Claim [test only]
 description: This endpoint allows a user to create a Loss Claim against an income source for a specific tax year. Claims cannot be made until after the End of Period Statement.

--- a/resources/public/api/conf/1.0/lossClaims_delete.raml
+++ b/resources/public/api/conf/1.0/lossClaims_delete.raml
@@ -5,7 +5,7 @@ is:
   - errors.formatNino
   - errors.formatClaimId
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundClaimId
 displayName: Delete a Loss Claim [test only]
 description: This endpoint allows the user to remove a previously entered loss claim.
 (annotations.sandboxData): !include scenarios/lossClaims_delete.md

--- a/resources/public/api/conf/1.0/lossClaims_get.raml
+++ b/resources/public/api/conf/1.0/lossClaims_get.raml
@@ -4,7 +4,7 @@ is:
   - errors.formatNino
   - errors.formatClaimId
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundClaimId
 displayName: Retrieve a Loss Claim [test only]
 description: This endpoint allows the user to retrieve the detail of an existing loss claim.
 (annotations.sandboxData): !include scenarios/lossClaims_get.md

--- a/resources/public/api/conf/1.0/lossClaims_list.raml
+++ b/resources/public/api/conf/1.0/lossClaims_list.raml
@@ -9,7 +9,7 @@ is:
   - errors.formatLossType
   - errors.formatSelfEmploymentId
   - errors.clientOrAgentNotAuthorised
-  - errors.notFound
+  - errors.notFoundNino
   - queryParameters.taxYearForClaims
   - queryParameters.typeOfLossForClaims
   - queryParameters.selfEmploymentId


### PR DESCRIPTION
Losses
————
Create
The remote endpoint has indicated that the given income source could not be found
Retrieve
The remote endpoint has indicated that no data can be found for the given loss ID
Amend
The remote endpoint has indicated that no data can be found for the given loss ID
List
The remote endpoint has indicated that no data can be found for the given NINO
Delete
The remote endpoint has indicated that no data can be found for the given loss ID

Claims
————
Create
The remote endpoint has indicated that the given income source could not be found
Retrieve
The remote endpoint has indicated that no data can be found for the given claim ID
Amend
The remote endpoint has indicated that no data can be found for the given claim ID
List
The remote endpoint has indicated that no data can be found for the given NINO
Delete
The remote endpoint has indicated that no data can be found for the given claim ID