### PR TITLE
[MTDSA-5592] Added Tax Year Not Supported to Amend Loss Claims Order

### DIFF
--- a/app/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidation.scala
+++ b/app/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidation.scala
@@ -27,7 +27,7 @@ object ClaimOrderTaxYearValidation {
 
       val start = taxYear.substring(2, 4).toInt
       val end   = taxYear.substring(5, 7).toInt
-      val startYear = taxYear.substring(0,4).toInt
+      val startYear = taxYear.substring(0, 4).toInt
 
       if (end - start == 1) {
         if (startYear < 2019) {

--- a/app/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidation.scala
+++ b/app/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidation.scala
@@ -25,8 +25,8 @@ object ClaimOrderTaxYearValidation {
   def validate(taxYear: String): List[MtdError] = {
     if (taxYear.matches(taxYearFormat)) {
 
-      val start = taxYear.substring(2, 4).toInt
-      val end   = taxYear.substring(5, 7).toInt
+      val start     = taxYear.substring(2, 4).toInt
+      val end       = taxYear.substring(5, 7).toInt
       val startYear = taxYear.substring(0, 4).toInt
 
       if (end - start == 1) {

--- a/app/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidation.scala
+++ b/app/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidation.scala
@@ -16,7 +16,7 @@
 
 package v1.controllers.requestParsers.validators.validations
 
-import v1.models.errors.{MtdError, TaxYearFormatError}
+import v1.models.errors.{MtdError, RuleTaxYearNotSupportedError, TaxYearFormatError}
 
 object ClaimOrderTaxYearValidation {
 
@@ -27,9 +27,15 @@ object ClaimOrderTaxYearValidation {
 
       val start = taxYear.substring(2, 4).toInt
       val end   = taxYear.substring(5, 7).toInt
+      val startYear = taxYear.substring(0,4).toInt
 
       if (end - start == 1) {
-        NoValidationErrors
+        if (startYear < 2019) {
+          print(startYear)
+          List(RuleTaxYearNotSupportedError)
+        } else {
+          NoValidationErrors
+        }
       } else {
         List(TaxYearFormatError)
       }
@@ -37,5 +43,4 @@ object ClaimOrderTaxYearValidation {
       List(TaxYearFormatError)
     }
   }
-
 }

--- a/resources/public/api/conf/1.0/lossClaimsOrder_amend.raml
+++ b/resources/public/api/conf/1.0/lossClaimsOrder_amend.raml
@@ -13,6 +13,7 @@ is:
   - errors.incorrectOrEmptyBody
   - errors.clientOrAgentNotAuthorised
   - errors.notFoundClaimId
+  - errors.ruleTaxYearNotSupported
   - queryParameters.taxYearForClaims
 displayName: Amend Loss Claims Order [test only]
 description: This endpoint allows the developer to change the sequence in which certain losses are used.

--- a/test/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidationSpec.scala
+++ b/test/v1/controllers/requestParsers/validators/validations/ClaimOrderTaxYearValidationSpec.scala
@@ -17,7 +17,7 @@
 package v1.controllers.requestParsers.validators.validations
 
 import support.UnitSpec
-import v1.models.errors.TaxYearFormatError
+import v1.models.errors.{RuleTaxYearNotSupportedError, TaxYearFormatError}
 import v1.models.utils.JsonErrorValidators
 
 class ClaimOrderTaxYearValidationSpec extends UnitSpec with JsonErrorValidators {
@@ -26,7 +26,7 @@ class ClaimOrderTaxYearValidationSpec extends UnitSpec with JsonErrorValidators 
     "return no errors" when {
       "when a valid tax year is supplied" in {
 
-        val validTaxYear = "2018-19"
+        val validTaxYear = "2019-20"
         val validationResult = ClaimOrderTaxYearValidation.validate(validTaxYear)
         validationResult.isEmpty shouldBe true
 
@@ -82,6 +82,14 @@ class ClaimOrderTaxYearValidationSpec extends UnitSpec with JsonErrorValidators 
       validationResult.isEmpty shouldBe false
       validationResult.length shouldBe 1
       validationResult.head shouldBe TaxYearFormatError
+    }
+
+    "the tax year predates 2019-20" in {
+      val invalidTaxYear = "2018-19"
+      val validationResult = ClaimOrderTaxYearValidation.validate(invalidTaxYear)
+      validationResult.isEmpty shouldBe false
+      validationResult.length shouldBe 1
+      validationResult.head shouldBe RuleTaxYearNotSupportedError
     }
 
   }


### PR DESCRIPTION
Applied the error to account for the tax year being before 2019-20