### PR TITLE
Update downstream error code for v2 in Delete BF Loss

### DIFF
--- a/app/v2/controllers/DeleteBFLossController.scala
+++ b/app/v2/controllers/DeleteBFLossController.scala
@@ -18,17 +18,17 @@ package v2.controllers
 
 import cats.data.EitherT
 import cats.implicits._
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.{ Action, AnyContent, ControllerComponents }
 import uk.gov.hmrc.http.HeaderCarrier
 import v2.controllers.requestParsers.DeleteBFLossParser
-import v2.models.audit.{AuditEvent, AuditResponse, DeleteBFLossAuditDetail}
+import v2.models.audit.{ AuditEvent, AuditResponse, DeleteBFLossAuditDetail }
 import v2.models.errors._
 import v2.models.requestData.DeleteBFLossRawData
 import v2.services._
 
-import scala.concurrent.{ExecutionContext, Future}
+import javax.inject.{ Inject, Singleton }
+import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
 class DeleteBFLossController @Inject()(val authService: EnrolmentsAuthService,
@@ -37,26 +37,26 @@ class DeleteBFLossController @Inject()(val authService: EnrolmentsAuthService,
                                        deleteBFLossParser: DeleteBFLossParser,
                                        auditService: AuditService,
                                        cc: ControllerComponents)(implicit ec: ExecutionContext)
-  extends AuthorisedController(cc) with BaseController {
+    extends AuthorisedController(cc)
+    with BaseController {
 
   implicit val endpointLogContext: EndpointLogContext =
     EndpointLogContext(controllerName = "DeleteBFLossController", endpointName = "Delete a Brought Forward Loss")
 
   def delete(nino: String, lossId: String): Action[AnyContent] =
     authorisedAction(nino).async { implicit request =>
-
       val rawData = DeleteBFLossRawData(nino, lossId)
       val result =
         for {
-          parsedRequest <- EitherT.fromEither[Future](deleteBFLossParser.parseRequest(rawData))
+          parsedRequest  <- EitherT.fromEither[Future](deleteBFLossParser.parseRequest(rawData))
           vendorResponse <- EitherT(deleteBFLossService.deleteBFLoss(parsedRequest))
         } yield {
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +
               s"Success response received with CorrelationId: ${vendorResponse.correlationId}")
 
-          auditSubmission(DeleteBFLossAuditDetail(request.userDetails, nino, lossId,
-            vendorResponse.correlationId, AuditResponse(NO_CONTENT, None, None)))
+          auditSubmission(
+            DeleteBFLossAuditDetail(request.userDetails, nino, lossId, vendorResponse.correlationId, AuditResponse(NO_CONTENT, None, None)))
 
           NoContent
             .withApiHeaders(vendorResponse.correlationId)
@@ -64,30 +64,29 @@ class DeleteBFLossController @Inject()(val authService: EnrolmentsAuthService,
 
       result.leftMap { errorWrapper =>
         val correlationId = getCorrelationId(errorWrapper)
-        val result = errorResult(errorWrapper).withApiHeaders(correlationId)
+        val result        = errorResult(errorWrapper).withApiHeaders(correlationId)
 
-        auditSubmission(DeleteBFLossAuditDetail(request.userDetails, nino, lossId,
-          correlationId, AuditResponse(result.header.status, Left(errorWrapper.auditErrors))))
+        auditSubmission(
+          DeleteBFLossAuditDetail(request.userDetails,
+                                  nino,
+                                  lossId,
+                                  correlationId,
+                                  AuditResponse(result.header.status, Left(errorWrapper.auditErrors))))
 
         result
       }.merge
     }
 
-
   private def errorResult(errorWrapper: ErrorWrapper) = {
     (errorWrapper.error: @unchecked) match {
-      case BadRequestError
-           | NinoFormatError
-           | LossIdFormatError => BadRequest(Json.toJson(errorWrapper))
-      case RuleDeleteAfterCrystallisationError => Forbidden(Json.toJson(errorWrapper))
-      case NotFoundError => NotFound(Json.toJson(errorWrapper))
-      case DownstreamError => InternalServerError(Json.toJson(errorWrapper))
+      case BadRequestError | NinoFormatError | LossIdFormatError => BadRequest(Json.toJson(errorWrapper))
+      case RuleDeleteAfterCrystallisationError                   => Forbidden(Json.toJson(errorWrapper))
+      case NotFoundError                                         => NotFound(Json.toJson(errorWrapper))
+      case DownstreamError                                       => InternalServerError(Json.toJson(errorWrapper))
     }
   }
 
-  private def auditSubmission(details: DeleteBFLossAuditDetail)
-                             (implicit hc: HeaderCarrier,
-                              ec: ExecutionContext) = {
+  private def auditSubmission(details: DeleteBFLossAuditDetail)(implicit hc: HeaderCarrier, ec: ExecutionContext) = {
     val event = AuditEvent("deleteBroughtForwardLoss", "delete-brought-forward-Loss", details)
     auditService.auditEvent(event)
   }

--- a/app/v2/services/DeleteBFLossService.scala
+++ b/app/v2/services/DeleteBFLossService.scala
@@ -16,13 +16,13 @@
 
 package v2.services
 
-import javax.inject.Inject
 import uk.gov.hmrc.http.HeaderCarrier
 import v2.connectors.BFLossConnector
 import v2.models.errors._
 import v2.models.requestData.DeleteBFLossRequest
 
-import scala.concurrent.{ExecutionContext, Future}
+import javax.inject.Inject
+import scala.concurrent.{ ExecutionContext, Future }
 
 class DeleteBFLossService @Inject()(connector: BFLossConnector) extends DesServiceSupport {
 
@@ -39,11 +39,11 @@ class DeleteBFLossService @Inject()(connector: BFLossConnector) extends DesServi
   }
 
   private def mappingDesToMtdError: Map[String, MtdError] = Map(
-    "INVALID_IDVALUE"     -> NinoFormatError,
-    "INVALID_LOSS_ID"     -> LossIdFormatError,
-    "NOT_FOUND"           -> NotFoundError,
-    "CONFLICT"            -> RuleDeleteAfterCrystallisationError,
-    "SERVER_ERROR"        -> DownstreamError,
-    "SERVICE_UNAVAILABLE" -> DownstreamError
+    "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+    "INVALID_LOSS_ID"           -> LossIdFormatError,
+    "NOT_FOUND"                 -> NotFoundError,
+    "CONFLICT"                  -> RuleDeleteAfterCrystallisationError,
+    "SERVER_ERROR"              -> DownstreamError,
+    "SERVICE_UNAVAILABLE"       -> DownstreamError
   )
 }

--- a/it/v2/endpoints/DeleteBFLossControllerISpec.scala
+++ b/it/v2/endpoints/DeleteBFLossControllerISpec.scala
@@ -19,11 +19,11 @@ package v2.endpoints
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status
-import play.api.libs.json.{JsObject, Json}
-import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.libs.json.{ JsObject, Json }
+import play.api.libs.ws.{ WSRequest, WSResponse }
 import support.V2IntegrationBaseSpec
 import v2.models.errors._
-import v2.stubs.{AuditStub, AuthStub, DesStub, MtdIdLookupStub}
+import v2.stubs.{ AuditStub, AuthStub, DesStub, MtdIdLookupStub }
 
 class DeleteBFLossControllerISpec extends V2IntegrationBaseSpec {
 
@@ -93,7 +93,7 @@ class DeleteBFLossControllerISpec extends V2IntegrationBaseSpec {
         }
       }
 
-      serviceErrorTest(Status.BAD_REQUEST, "INVALID_IDVALUE", Status.BAD_REQUEST, NinoFormatError)
+      serviceErrorTest(Status.BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", Status.BAD_REQUEST, NinoFormatError)
       serviceErrorTest(Status.BAD_REQUEST, "INVALID_LOSS_ID", Status.BAD_REQUEST, LossIdFormatError)
       serviceErrorTest(Status.BAD_REQUEST, "UNEXPECTED_DES_ERROR_CODE", Status.INTERNAL_SERVER_ERROR, DownstreamError)
       serviceErrorTest(Status.NOT_FOUND, "NOT_FOUND", Status.NOT_FOUND, NotFoundError)

--- a/test/v2/services/DeleteBFLossServiceSpec.scala
+++ b/test/v2/services/DeleteBFLossServiceSpec.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future
 
 class DeleteBFLossServiceSpec extends ServiceSpec {
 
-  val nino: String = "AA123456A"
+  val nino: String   = "AA123456A"
   val lossId: String = "AAZZ1234567890a"
 
   trait Test extends MockBFLossConnector {
@@ -39,7 +39,7 @@ class DeleteBFLossServiceSpec extends ServiceSpec {
     "return a Right" when {
       "the connector call is successful" in new Test {
         val desResponse: DesResponse[Unit] = DesResponse(correlationId, ())
-        val expected: DesResponse[Unit] = DesResponse(correlationId, ())
+        val expected: DesResponse[Unit]    = DesResponse(correlationId, ())
         MockedBFLossConnector.deleteBFLoss(request).returns(Future.successful(Right(desResponse)))
 
         await(service.deleteBFLoss(request)) shouldBe Right(expected)
@@ -48,7 +48,7 @@ class DeleteBFLossServiceSpec extends ServiceSpec {
 
     "return that wrapped error as-is" when {
       "the connector returns an outbound error" in new Test {
-        val someError: MtdError = MtdError("SOME_CODE", "some message")
+        val someError: MtdError                     = MtdError("SOME_CODE", "some message")
         val desResponse: DesResponse[OutboundError] = DesResponse(correlationId, OutboundError(someError))
         MockedBFLossConnector.deleteBFLoss(request).returns(Future.successful(Left(desResponse)))
 
@@ -59,14 +59,14 @@ class DeleteBFLossServiceSpec extends ServiceSpec {
     "return a downstream error" when {
       "the connector call returns a single downstream error" in new Test {
         val desResponse: DesResponse[SingleError] = DesResponse(correlationId, SingleError(DownstreamError))
-        val expected: ErrorWrapper = ErrorWrapper(Some(correlationId), DownstreamError, None)
+        val expected: ErrorWrapper                = ErrorWrapper(Some(correlationId), DownstreamError, None)
         MockedBFLossConnector.deleteBFLoss(request).returns(Future.successful(Left(desResponse)))
 
         await(service.deleteBFLoss(request)) shouldBe Left(expected)
       }
       "the connector call returns multiple errors including a downstream error" in new Test {
         val desResponse: DesResponse[MultipleErrors] = DesResponse(correlationId, MultipleErrors(Seq(NinoFormatError, DownstreamError)))
-        val expected: ErrorWrapper = ErrorWrapper(Some(correlationId), DownstreamError, None)
+        val expected: ErrorWrapper                   = ErrorWrapper(Some(correlationId), DownstreamError, None)
         MockedBFLossConnector.deleteBFLoss(request).returns(Future.successful(Left(desResponse)))
 
         await(service.deleteBFLoss(request)) shouldBe Left(expected)
@@ -74,18 +74,20 @@ class DeleteBFLossServiceSpec extends ServiceSpec {
     }
 
     Map(
-      "INVALID_IDVALUE"     -> NinoFormatError,
-      "INVALID_LOSS_ID"     -> LossIdFormatError,
-      "NOT_FOUND"           -> NotFoundError,
-      "CONFLICT"            -> RuleDeleteAfterCrystallisationError,
-      "SERVER_ERROR"        -> DownstreamError,
-      "SERVICE_UNAVAILABLE" -> DownstreamError,
-      "UNEXPECTED_ERROR"    -> DownstreamError
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_LOSS_ID"           -> LossIdFormatError,
+      "NOT_FOUND"                 -> NotFoundError,
+      "CONFLICT"                  -> RuleDeleteAfterCrystallisationError,
+      "SERVER_ERROR"              -> DownstreamError,
+      "SERVICE_UNAVAILABLE"       -> DownstreamError,
+      "UNEXPECTED_ERROR"          -> DownstreamError
     ).foreach {
-      case(k, v) =>
+      case (k, v) =>
         s"return a ${v.code} error" when {
           s"the connector call returns $k" in new Test {
-            MockedBFLossConnector.deleteBFLoss(request).returns(Future.successful(Left(DesResponse(correlationId, SingleError(MtdError(k, "doesn't matter"))))))
+            MockedBFLossConnector
+              .deleteBFLoss(request)
+              .returns(Future.successful(Left(DesResponse(correlationId, SingleError(MtdError(k, "doesn't matter"))))))
 
             await(service.deleteBFLoss(request)) shouldBe Left(ErrorWrapper(Some(correlationId), v, None))
           }


### PR DESCRIPTION
Lots of auto-formatting in this makes the change look bigger than it is... it's really just changing the error mapping for v2 from INVALID_IDVALUE to INVALID_TAXABLE_ENTITY_ID.