### PR TITLE
MTDSA-14614: List Loss Claims Connector Refactor

### DIFF
--- a/app/api/endpoints/lossClaim/connector/v3/LossClaimConnector.scala
+++ b/app/api/endpoints/lossClaim/connector/v3/LossClaimConnector.scala
@@ -16,17 +16,15 @@
 
 package api.endpoints.lossClaim.connector.v3
 
-import api.connectors.{ BaseDownstreamConnector, DownstreamOutcome, DownstreamUri }
 import api.connectors.DownstreamUri.{ DesUri, IfsUri, TaxYearSpecificIfsUri }
 import api.connectors.httpparsers.StandardDownstreamHttpParser._
+import api.connectors.{ BaseDownstreamConnector, DownstreamOutcome }
 import api.endpoints.lossClaim.amendOrder.v3.request.AmendLossClaimsOrderRequest
 import api.endpoints.lossClaim.amendType.v3.request.AmendLossClaimTypeRequest
 import api.endpoints.lossClaim.amendType.v3.response.AmendLossClaimTypeResponse
 import api.endpoints.lossClaim.create.v3.request.CreateLossClaimRequest
 import api.endpoints.lossClaim.create.v3.response.CreateLossClaimResponse
 import api.endpoints.lossClaim.delete.v3.request.DeleteLossClaimRequest
-import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
-import api.endpoints.lossClaim.list.v3.response.{ ListLossClaimsItem, ListLossClaimsResponse }
 import api.endpoints.lossClaim.retrieve.v3.request.RetrieveLossClaimRequest
 import api.endpoints.lossClaim.retrieve.v3.response.RetrieveLossClaimResponse
 import config.AppConfig
@@ -36,19 +34,18 @@ import javax.inject.{ Inject, Singleton }
 import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
-class LossClaimConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+class LossClaimConnector @Inject() (val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
 
   def createLossClaim(request: CreateLossClaimRequest)(implicit
-                                                       hc: HeaderCarrier,
-                                                       ec: ExecutionContext,
-                                                       correlationId: String): Future[DownstreamOutcome[CreateLossClaimResponse]] = {
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[CreateLossClaimResponse]] = {
     val nino = request.nino.nino
 
     post(request.lossClaim, IfsUri[CreateLossClaimResponse](s"income-tax/claims-for-relief/$nino"))
   }
 
-  def amendLossClaimType(amendLossClaimTypeRequest: AmendLossClaimTypeRequest)(
-      implicit
+  def amendLossClaimType(amendLossClaimTypeRequest: AmendLossClaimTypeRequest)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext,
       correlationId: String): Future[DownstreamOutcome[AmendLossClaimTypeResponse]] = {
@@ -59,40 +56,13 @@ class LossClaimConnector @Inject()(val http: HttpClient, val appConfig: AppConfi
   }
 
   def retrieveLossClaim(request: RetrieveLossClaimRequest)(implicit
-                                                           hc: HeaderCarrier,
-                                                           ec: ExecutionContext,
-                                                           correlationId: String): Future[DownstreamOutcome[RetrieveLossClaimResponse]] = {
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[RetrieveLossClaimResponse]] = {
     val nino    = request.nino.nino
     val claimId = request.claimId
 
     get(IfsUri[RetrieveLossClaimResponse](s"income-tax/claims-for-relief/$nino/$claimId"))
-  }
-
-  def listLossClaims(request: ListLossClaimsRequest)(implicit
-                                                     hc: HeaderCarrier,
-                                                     ec: ExecutionContext,
-                                                     correlationId: String): Future[DownstreamOutcome[ListLossClaimsResponse[ListLossClaimsItem]]] = {
-    import request._
-
-    val pathParameters = Map(
-      "taxYear"          -> taxYearClaimedFor.map(_.asDownstream),
-      "incomeSourceId"   -> businessId,
-      "incomeSourceType" -> typeOfLoss.flatMap(_.toIncomeSourceType).map(_.toString),
-      "claimType"        -> typeOfClaim.map(_.toReliefClaimed.toString)
-    ).collect {
-      case (key, Some(value)) => key -> value
-    }
-
-    val (uri: DownstreamUri[ListLossClaimsResponse[ListLossClaimsItem]], downstreamSpecificParameters) = taxYearClaimedFor match {
-      case Some(taxYear) if taxYear.useTaxYearSpecificApi =>
-        (
-          TaxYearSpecificIfsUri[ListLossClaimsResponse[ListLossClaimsItem]](s"income-tax/claims-for-relief/${taxYear.asTysDownstream}/${nino.nino}"),
-          pathParameters.filterNot { case (key, _) => key == "taxYear" }
-        )
-      case _ => (IfsUri[ListLossClaimsResponse[ListLossClaimsItem]](s"income-tax/claims-for-relief/${nino.nino}"), pathParameters)
-    }
-
-    get(uri, downstreamSpecificParameters.toSeq)
   }
 
   def deleteLossClaim(
@@ -103,9 +73,10 @@ class LossClaimConnector @Inject()(val http: HttpClient, val appConfig: AppConfi
     delete(DesUri[Unit](s"income-tax/claims-for-relief/$nino/$claimId"))
   }
 
-  def amendLossClaimsOrder(request: AmendLossClaimsOrderRequest)(implicit hc: HeaderCarrier,
-                                                                 ec: ExecutionContext,
-                                                                 correlationId: String): Future[DownstreamOutcome[Unit]] = {
+  def amendLossClaimsOrder(request: AmendLossClaimsOrderRequest)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[Unit]] = {
     val nino    = request.nino.nino
     val taxYear = request.taxYearClaimedFor
 
@@ -121,4 +92,5 @@ class LossClaimConnector @Inject()(val http: HttpClient, val appConfig: AppConfi
       body = request.body
     )
   }
+
 }

--- a/app/api/endpoints/lossClaim/list/v3/ListLossClaimsService.scala
+++ b/app/api/endpoints/lossClaim/list/v3/ListLossClaimsService.scala
@@ -17,7 +17,7 @@
 package api.endpoints.lossClaim.list.v3
 
 import api.controllers.RequestContext
-import api.endpoints.lossClaim.connector.v3.LossClaimConnector
+import api.endpoints.lossClaim.connector.v3.ListLossClaimsConnector
 import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
 import api.models.errors._
 import api.services.BaseService
@@ -26,7 +26,7 @@ import api.services.v3.Outcomes.ListLossClaimsOutcome
 import javax.inject.Inject
 import scala.concurrent.{ ExecutionContext, Future }
 
-class ListLossClaimsService @Inject() (connector: LossClaimConnector) extends BaseService {
+class ListLossClaimsService @Inject() (connector: ListLossClaimsConnector) extends BaseService {
 
   def listLossClaims(request: ListLossClaimsRequest)(implicit ctx: RequestContext, ec: ExecutionContext): Future[ListLossClaimsOutcome] =
     connector

--- a/app/api/endpoints/lossClaim/list/v3/ListLossClaimsService.scala
+++ b/app/api/endpoints/lossClaim/list/v3/ListLossClaimsService.scala
@@ -17,7 +17,7 @@
 package api.endpoints.lossClaim.list.v3
 
 import api.controllers.RequestContext
-import api.endpoints.lossClaim.connector.v3.ListLossClaimsConnector
+import api.endpoints.lossClaim.list.v3.connector.ListLossClaimsConnector
 import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
 import api.models.errors._
 import api.services.BaseService

--- a/app/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnector.scala
+++ b/app/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnector.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.endpoints.lossClaim.connector.v3
+
+import api.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import api.connectors.httpparsers.StandardDownstreamHttpParser._
+import api.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
+import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
+import api.endpoints.lossClaim.list.v3.response.{ListLossClaimsItem, ListLossClaimsResponse}
+import config.AppConfig
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ListLossClaimsConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def listLossClaims(request: ListLossClaimsRequest)(implicit
+                                                     hc: HeaderCarrier,
+                                                     ec: ExecutionContext,
+                                                     correlationId: String): Future[DownstreamOutcome[ListLossClaimsResponse[ListLossClaimsItem]]] = {
+    import request._
+
+    val pathParameters = Map(
+      "taxYear"          -> taxYearClaimedFor.map(_.asDownstream),
+      "incomeSourceId"   -> businessId,
+      "incomeSourceType" -> typeOfLoss.flatMap(_.toIncomeSourceType).map(_.toString),
+      "claimType"        -> typeOfClaim.map(_.toReliefClaimed.toString)
+    ).collect {
+      case (key, Some(value)) => key -> value
+    }
+
+    val (uri: DownstreamUri[ListLossClaimsResponse[ListLossClaimsItem]], downstreamSpecificParameters) = taxYearClaimedFor match {
+      case Some(taxYear) if taxYear.useTaxYearSpecificApi =>
+        (
+          TaxYearSpecificIfsUri[ListLossClaimsResponse[ListLossClaimsItem]](s"income-tax/claims-for-relief/${taxYear.asTysDownstream}/${nino.nino}"),
+          pathParameters.filterNot { case (key, _) => key == "taxYear" }
+        )
+      case _ => (IfsUri[ListLossClaimsResponse[ListLossClaimsItem]](s"income-tax/claims-for-relief/${nino.nino}"), pathParameters)
+    }
+
+    get(uri, downstreamSpecificParameters.toSeq)
+  }
+
+}

--- a/app/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnector.scala
+++ b/app/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnector.scala
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package api.endpoints.lossClaim.connector.v3
+package api.endpoints.lossClaim.list.v3.connector
 
-import api.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import api.connectors.DownstreamUri.{ IfsUri, TaxYearSpecificIfsUri }
 import api.connectors.httpparsers.StandardDownstreamHttpParser._
-import api.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
+import api.connectors.{ BaseDownstreamConnector, DownstreamOutcome, DownstreamUri }
 import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
-import api.endpoints.lossClaim.list.v3.response.{ListLossClaimsItem, ListLossClaimsResponse}
+import api.endpoints.lossClaim.list.v3.response.{ ListLossClaimsItem, ListLossClaimsResponse }
 import config.AppConfig
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import uk.gov.hmrc.http.{ HeaderCarrier, HttpClient }
 
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import javax.inject.{ Inject, Singleton }
+import scala.concurrent.{ ExecutionContext, Future }
 
 @Singleton
-class ListLossClaimsConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+class ListLossClaimsConnector @Inject() (val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
 
   def listLossClaims(request: ListLossClaimsRequest)(implicit
-                                                     hc: HeaderCarrier,
-                                                     ec: ExecutionContext,
-                                                     correlationId: String): Future[DownstreamOutcome[ListLossClaimsResponse[ListLossClaimsItem]]] = {
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[ListLossClaimsResponse[ListLossClaimsItem]]] = {
     import request._
 
     val pathParameters = Map(
@@ -41,8 +41,8 @@ class ListLossClaimsConnector @Inject()(val http: HttpClient, val appConfig: App
       "incomeSourceId"   -> businessId,
       "incomeSourceType" -> typeOfLoss.flatMap(_.toIncomeSourceType).map(_.toString),
       "claimType"        -> typeOfClaim.map(_.toReliefClaimed.toString)
-    ).collect {
-      case (key, Some(value)) => key -> value
+    ).collect { case (key, Some(value)) =>
+      key -> value
     }
 
     val (uri: DownstreamUri[ListLossClaimsResponse[ListLossClaimsItem]], downstreamSpecificParameters) = taxYearClaimedFor match {

--- a/test/api/endpoints/lossClaim/connector/v3/MockLossClaimConnector.scala
+++ b/test/api/endpoints/lossClaim/connector/v3/MockLossClaimConnector.scala
@@ -23,8 +23,6 @@ import api.endpoints.lossClaim.amendType.v3.response.AmendLossClaimTypeResponse
 import api.endpoints.lossClaim.create.v3.request.CreateLossClaimRequest
 import api.endpoints.lossClaim.create.v3.response.CreateLossClaimResponse
 import api.endpoints.lossClaim.delete.v3.request.DeleteLossClaimRequest
-import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
-import api.endpoints.lossClaim.list.v3.response.{ListLossClaimsItem, ListLossClaimsResponse}
 import api.endpoints.lossClaim.retrieve.v3.request.RetrieveLossClaimRequest
 import api.endpoints.lossClaim.retrieve.v3.response.RetrieveLossClaimResponse
 import org.scalamock.handlers.CallHandler
@@ -61,12 +59,6 @@ trait MockLossClaimConnector extends MockFactory {
       (connector
         .deleteLossClaim(_: DeleteLossClaimRequest)(_: HeaderCarrier, _: ExecutionContext, _: String))
         .expects(deleteLossClaimRequest, *, *, *)
-    }
-
-    def listLossClaims(request: ListLossClaimsRequest): CallHandler[Future[DownstreamOutcome[ListLossClaimsResponse[ListLossClaimsItem]]]] = {
-      (connector
-        .listLossClaims(_: ListLossClaimsRequest)(_: HeaderCarrier, _: ExecutionContext, _: String))
-        .expects(request, *, *, *)
     }
 
     def amendLossClaimsOrder(request: AmendLossClaimsOrderRequest): CallHandler[Future[DownstreamOutcome[Unit]]] = {

--- a/test/api/endpoints/lossClaim/list/v3/ListLossClaimsControllerSpec.scala
+++ b/test/api/endpoints/lossClaim/list/v3/ListLossClaimsControllerSpec.scala
@@ -20,6 +20,7 @@ import api.controllers.{ ControllerBaseSpec, ControllerTestRunner }
 import api.endpoints.lossClaim.domain.v3.{ TypeOfClaim, TypeOfLoss }
 import api.endpoints.lossClaim.list.v3.request.{ ListLossClaimsRawData, ListLossClaimsRequest, MockListLossClaimsRequestDataParser }
 import api.endpoints.lossClaim.list.v3.response.{ ListLossClaimsHateoasData, ListLossClaimsItem, ListLossClaimsResponse }
+import api.fixtures.ListLossClaimsFixtures.multipleListLossClaimsResponseModel
 import api.hateoas.MockHateoasFactory
 import api.models.ResponseWrapper
 import api.models.domain.{ Nino, TaxYear }
@@ -49,26 +50,6 @@ class ListLossClaimsControllerSpec
 
   private val testHateoasLink       = Link(href = "/foo/bar", method = GET, rel = "test-relationship")
   private val testCreateHateoasLink = Link(href = "/foo/bar", method = POST, rel = "test-create-relationship")
-
-  private val response: ListLossClaimsResponse[ListLossClaimsItem] = ListLossClaimsResponse(
-    Seq(
-      ListLossClaimsItem(
-        "businessId",
-        TypeOfClaim.`carry-sideways`,
-        TypeOfLoss.`self-employment`,
-        "2020",
-        "claimId",
-        Some(1),
-        "2020-07-13T12:13:48.763Z"),
-      ListLossClaimsItem(
-        "businessId1",
-        TypeOfClaim.`carry-sideways`,
-        TypeOfLoss.`self-employment`,
-        "2020",
-        "claimId1",
-        Some(2),
-        "2020-07-13T12:13:48.763Z")
-    ))
 
   private val hateoasResponse: ListLossClaimsResponse[HateoasWrapper[ListLossClaimsItem]] = ListLossClaimsResponse(
     Seq(
@@ -153,10 +134,10 @@ class ListLossClaimsControllerSpec
 
         MockListLossClaimsService
           .list(request)
-          .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, multipleListLossClaimsResponseModel))))
 
         MockHateoasFactory
-          .wrapList(response, ListLossClaimsHateoasData(nino))
+          .wrapList(multipleListLossClaimsResponseModel, ListLossClaimsHateoasData(nino))
           .returns(HateoasWrapper(hateoasResponse, Seq(testCreateHateoasLink)))
 
         runOkTest(expectedStatus = OK, maybeExpectedResponseBody = Some(mtdResponseJson))

--- a/test/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnectorSpec.scala
+++ b/test/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnectorSpec.scala
@@ -17,10 +17,11 @@
 package api.endpoints.lossClaim.list.v3.connector
 
 import api.connectors.{ ConnectorSpec, DownstreamOutcome }
-import api.endpoints.lossClaim.connector.v3.LossClaimConnector
+import api.endpoints.lossClaim.connector.v3.ListLossClaimsConnector
 import api.endpoints.lossClaim.domain.v3.{ TypeOfClaim, TypeOfLoss }
 import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
 import api.endpoints.lossClaim.list.v3.response.{ ListLossClaimsItem, ListLossClaimsResponse }
+import api.fixtures.ListLossClaimsFixtures._
 import api.models.ResponseWrapper
 import api.models.domain.{ Nino, TaxYear }
 
@@ -33,160 +34,50 @@ class ListLossClaimsConnectorSpec extends ConnectorSpec {
 
   trait Test {
     _: ConnectorTest =>
-    val connector: LossClaimConnector = new LossClaimConnector(http = mockHttpClient, appConfig = mockAppConfig)
+    val connector: ListLossClaimsConnector = new ListLossClaimsConnector(http = mockHttpClient, appConfig = mockAppConfig)
+
   }
 
   "list LossClaims" when {
     "a valid request is supplied with no query parameters" should {
       "return a successful response with the correct correlationId" in new IfsTest with Test {
-
-        val expected = Right(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, multipleListLossClaimsResponseModel))
 
         willGet(s"$baseUrl/income-tax/claims-for-relief/$nino") returns Future.successful(expected)
-
         listLossClaimsResult(connector) shouldBe expected
       }
 
       "return a successful response with the correct correlationId for a TYS tax year" in new TysIfsTest with Test {
-
-        val expected = Right(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, singleListLossClaimsResponseModel("2023-24")))
 
         willGet(s"$baseUrl/income-tax/claims-for-relief/23-24/$nino") returns Future.successful(expected)
-
         listLossClaimsResult(connector, Some(TaxYear.fromMtd("2023-24"))) shouldBe expected
       }
     }
 
     "provided with a tax year parameter" should {
       "return a successful response with the correct correlationId" in new IfsTest with Test {
-
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, singleListLossClaimsResponseModel("2018-19")))
 
         willGet(url = s"$baseUrl/income-tax/claims-for-relief/$nino", queryParams = List(("taxYear", "2019"))) returns Future.successful(expected)
-
         listLossClaimsResult(connector = connector, taxYear = Some(TaxYear("2019"))) shouldBe expected
       }
     }
 
     "provided with a income source id parameter" should {
       "return a successful response with the correct correlationId" in new IfsTest with Test {
+        val expected = Right(ResponseWrapper(correlationId, multipleListLossClaimsResponseModel))
 
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
-
-        willGet(url = s"$baseUrl/income-tax/claims-for-relief/$nino", queryParams = List(("incomeSourceId", "testId"))) returns Future.successful(
-          expected)
+        willGet(
+          url = s"$baseUrl/income-tax/claims-for-relief/$nino",
+          queryParams = List(("incomeSourceId", "testId"))
+        ) returns Future.successful(expected)
 
         listLossClaimsResult(connector = connector, businessId = Some("testId")) shouldBe expected
       }
 
       "return a successful response with the correct correlationId for a TYS tax year" in new TysIfsTest with Test {
-
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, singleListLossClaimsResponseModel("2023-24")))
 
         willGet(url = s"$baseUrl/income-tax/claims-for-relief/23-24/$nino", queryParams = List(("incomeSourceId", "testId"))) returns Future
           .successful(expected)
@@ -197,29 +88,7 @@ class ListLossClaimsConnectorSpec extends ConnectorSpec {
 
     "provided with a income source type parameter" should {
       "return a successful response with the correct correlationId" in new IfsTest with Test {
-
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, multipleListLossClaimsResponseModel))
 
         willGet(
           url = s"$baseUrl/income-tax/claims-for-relief/$nino",
@@ -230,32 +99,12 @@ class ListLossClaimsConnectorSpec extends ConnectorSpec {
       }
 
       "return a successful response with the correct correlationId for a TYS tax year" in new TysIfsTest with Test {
+        val expected = Right(ResponseWrapper(correlationId, singleListLossClaimsResponseModel("2023-24")))
 
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
-
-        willGet(url = s"$baseUrl/income-tax/claims-for-relief/23-24/$nino", queryParams = List(("incomeSourceType", "02"))) returns Future.successful(
-          expected)
+        willGet(
+          url = s"$baseUrl/income-tax/claims-for-relief/23-24/$nino",
+          queryParams = List(("incomeSourceType", "02"))
+        ) returns Future.successful(expected)
 
         listLossClaimsResult(
           connector = connector,
@@ -266,29 +115,7 @@ class ListLossClaimsConnectorSpec extends ConnectorSpec {
 
     "provided with a claim type parameter" should {
       "return a successful response with the correct correlationId" in new IfsTest with Test {
-
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, multipleListLossClaimsResponseModel))
 
         willGet(url = s"$baseUrl/income-tax/claims-for-relief/$nino", queryParams = List(("claimType", "CSGI"))) returns Future.successful(expected)
 
@@ -296,29 +123,7 @@ class ListLossClaimsConnectorSpec extends ConnectorSpec {
       }
 
       "return a successful response with the correct correlationId for a TYS tax year" in new TysIfsTest with Test {
-
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, singleListLossClaimsResponseModel("2023-24")))
 
         willGet(
           url = s"$baseUrl/income-tax/claims-for-relief/23-24/$nino",
@@ -334,29 +139,7 @@ class ListLossClaimsConnectorSpec extends ConnectorSpec {
 
     "provided with all parameters" should {
       "return a successful response with the correct correlationId for a TYS tax year" in new TysIfsTest with Test {
-
-        val expected = Left(
-          ResponseWrapper(
-            correlationId,
-            ListLossClaimsResponse(List(
-              ListLossClaimsItem(
-                "businessId",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId",
-                Some(1),
-                "2020-07-13T12:13:48.763Z"),
-              ListLossClaimsItem(
-                "businessId1",
-                TypeOfClaim.`carry-sideways`,
-                TypeOfLoss.`self-employment`,
-                "2020",
-                "claimId1",
-                Some(2),
-                "2020-07-13T12:13:48.763Z")
-            ))
-          ))
+        val expected = Right(ResponseWrapper(correlationId, singleListLossClaimsResponseModel("2023-24")))
 
         willGet(
           url = s"$baseUrl/income-tax/claims-for-relief/23-24/$nino",
@@ -373,7 +156,7 @@ class ListLossClaimsConnectorSpec extends ConnectorSpec {
       }
     }
 
-    def listLossClaimsResult(connector: LossClaimConnector,
+    def listLossClaimsResult(connector: ListLossClaimsConnector,
                              taxYear: Option[TaxYear] = None,
                              typeOfLoss: Option[TypeOfLoss] = None,
                              businessId: Option[String] = None,

--- a/test/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnectorSpec.scala
+++ b/test/api/endpoints/lossClaim/list/v3/connector/ListLossClaimsConnectorSpec.scala
@@ -17,7 +17,6 @@
 package api.endpoints.lossClaim.list.v3.connector
 
 import api.connectors.{ ConnectorSpec, DownstreamOutcome }
-import api.endpoints.lossClaim.connector.v3.ListLossClaimsConnector
 import api.endpoints.lossClaim.domain.v3.{ TypeOfClaim, TypeOfLoss }
 import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
 import api.endpoints.lossClaim.list.v3.response.{ ListLossClaimsItem, ListLossClaimsResponse }

--- a/test/api/endpoints/lossClaim/list/v3/connector/MockListLossClaimsConnector.scala
+++ b/test/api/endpoints/lossClaim/list/v3/connector/MockListLossClaimsConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.endpoints.lossClaim.list.v3.connector
+
+import api.connectors.DownstreamOutcome
+import api.endpoints.lossClaim.connector.v3.ListLossClaimsConnector
+import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
+import api.endpoints.lossClaim.list.v3.response.{ListLossClaimsItem, ListLossClaimsResponse}
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockListLossClaimsConnector extends MockFactory {
+  val connector: ListLossClaimsConnector = mock[ListLossClaimsConnector]
+
+  object MockedListLossClaimsConnector {
+
+    def listLossClaims(request: ListLossClaimsRequest): CallHandler[Future[DownstreamOutcome[ListLossClaimsResponse[ListLossClaimsItem]]]] = {
+      (connector
+        .listLossClaims(_: ListLossClaimsRequest)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(request, *, *, *)
+    }
+
+  }
+}

--- a/test/api/endpoints/lossClaim/list/v3/connector/MockListLossClaimsConnector.scala
+++ b/test/api/endpoints/lossClaim/list/v3/connector/MockListLossClaimsConnector.scala
@@ -17,14 +17,13 @@
 package api.endpoints.lossClaim.list.v3.connector
 
 import api.connectors.DownstreamOutcome
-import api.endpoints.lossClaim.connector.v3.ListLossClaimsConnector
 import api.endpoints.lossClaim.list.v3.request.ListLossClaimsRequest
-import api.endpoints.lossClaim.list.v3.response.{ListLossClaimsItem, ListLossClaimsResponse}
+import api.endpoints.lossClaim.list.v3.response.{ ListLossClaimsItem, ListLossClaimsResponse }
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait MockListLossClaimsConnector extends MockFactory {
   val connector: ListLossClaimsConnector = mock[ListLossClaimsConnector]
@@ -38,4 +37,5 @@ trait MockListLossClaimsConnector extends MockFactory {
     }
 
   }
+
 }

--- a/test/api/fixtures/ListLossClaimsFixtures.scala
+++ b/test/api/fixtures/ListLossClaimsFixtures.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.fixtures
+
+import api.endpoints.lossClaim.domain.v3.{ TypeOfClaim, TypeOfLoss }
+import api.endpoints.lossClaim.list.v3.response.{ ListLossClaimsItem, ListLossClaimsResponse }
+
+object ListLossClaimsFixtures {
+
+  def listLossClaimsModel(taxYear: String): ListLossClaimsItem = ListLossClaimsItem(
+    businessId = "testId",
+    typeOfClaim = TypeOfClaim.`carry-sideways`,
+    typeOfLoss = TypeOfLoss.`self-employment`,
+    taxYearClaimedFor = taxYear,
+    claimId = "claimId",
+    sequence = Some(1),
+    lastModified = "2020-07-13T12:13:48.763Z"
+  )
+
+  def singleListLossClaimsResponseModel(taxYear: String): ListLossClaimsResponse[ListLossClaimsItem] = ListLossClaimsResponse(
+    List(listLossClaimsModel(taxYear))
+  )
+
+  val multipleListLossClaimsResponseModel: ListLossClaimsResponse[ListLossClaimsItem] = ListLossClaimsResponse(
+    List(
+      listLossClaimsModel("2019-20"),
+      listLossClaimsModel("2020-21"),
+      listLossClaimsModel("2021-22"),
+      listLossClaimsModel("2022-23")
+    )
+  )
+
+}


### PR DESCRIPTION
As we are adding some custom logic to the ListLossClaimsConnector, I've pulled it out into it's own file, more in line with how other APIs are structured. Also simplified the tests by creating some Fixtures, which should make testing the multiple downstream requests scenario easier.