### PR TITLE
MTDSA-27528: API#1506 Amend A Loss Claim Type FHL Removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To view documentation locally, ensure the Individual Losses API is running, and 
 Then go to http://localhost:9680/api-documentation/docs/openapi/preview and use the appropriate port and version:
 
 ```
-http://localhost:9779/api/conf/4.0/application.yaml
+http://localhost:9779/api/conf/5.0/application.yaml
 ```
 
 ## Changelog

--- a/app/common/errors/LossesApiCommonErrors.scala
+++ b/app/common/errors/LossesApiCommonErrors.scala
@@ -38,6 +38,12 @@ object RuleDeleteAfterFinalDeclarationError
 object RuleTypeOfClaimInvalid
     extends MtdError("RULE_TYPE_OF_CLAIM_INVALID", "The claim type selected is not available for this type of loss", BAD_REQUEST)
 
+object RuleCSFHLClaimNotSupportedError
+    extends MtdError(
+      "RULE_CSFHL_CLAIM_NOT_SUPPORTED",
+      "carry-sideways-fhl claim for income sources foreign-property-fhl-eea and uk-property-fhl will not be supported from tax year 25/26",
+      BAD_REQUEST)
+
 object RuleClaimTypeNotChanged  extends MtdError("RULE_NO_CHANGE", "This claim matches a previous submission", BAD_REQUEST)
 object RulePeriodNotEnded       extends MtdError("RULE_ACCOUNTING_PERIOD_NOT_ENDED", "The accounting period has not yet ended", BAD_REQUEST)
 object RuleLossAmountNotChanged extends MtdError("RULE_NO_CHANGE", "The brought forward loss amount has not changed", BAD_REQUEST)

--- a/app/v5/lossClaims/amendType/AmendLossClaimTypeService.scala
+++ b/app/v5/lossClaims/amendType/AmendLossClaimTypeService.scala
@@ -17,7 +17,7 @@
 package v5.lossClaims.amendType
 
 import cats.implicits._
-import common.errors.{ClaimIdFormatError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
+import common.errors.{ClaimIdFormatError, RuleCSFHLClaimNotSupportedError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
 import shared.controllers.RequestContext
 import shared.models.errors._
 import shared.services.{BaseService, ServiceOutcome}
@@ -41,6 +41,7 @@ class AmendLossClaimTypeService @Inject() (connector: AmendLossClaimTypeConnecto
     "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
     "INVALID_PAYLOAD"           -> InternalError,
     "INVALID_CLAIM_TYPE"        -> RuleTypeOfClaimInvalid,
+    "CSFHL_CLAIM_NOT_SUPPORTED" -> RuleCSFHLClaimNotSupportedError,
     "NOT_FOUND"                 -> NotFoundError,
     "CONFLICT"                  -> RuleClaimTypeNotChanged,
     "INVALID_CORRELATIONID"     -> InternalError,

--- a/it/v5/lossClaim/amendType/def1/Def1_AmendLossClaimTypeISpec.scala
+++ b/it/v5/lossClaim/amendType/def1/Def1_AmendLossClaimTypeISpec.scala
@@ -17,7 +17,7 @@
 package v5.lossClaim.amendType.def1
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import common.errors.{ClaimIdFormatError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid, TypeOfClaimFormatError}
+import common.errors._
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status._
 import play.api.libs.json.{JsValue, Json}
@@ -131,6 +131,7 @@ class Def1_AmendLossClaimTypeISpec extends IntegrationBaseSpec {
       serviceErrorTest(BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError)
       serviceErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
       serviceErrorTest(UNPROCESSABLE_ENTITY, "INVALID_CLAIM_TYPE", BAD_REQUEST, RuleTypeOfClaimInvalid)
+      serviceErrorTest(UNPROCESSABLE_ENTITY, "CSFHL_CLAIM_NOT_SUPPORTED", BAD_REQUEST, RuleCSFHLClaimNotSupportedError)
       serviceErrorTest(CONFLICT, "CONFLICT", BAD_REQUEST, RuleClaimTypeNotChanged)
       serviceErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
       serviceErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)

--- a/resources/public/api/conf/5.0/common/errors.yaml
+++ b/resources/public/api/conf/5.0/common/errors.yaml
@@ -94,6 +94,13 @@ components:
         code: RULE_TYPE_OF_CLAIM_INVALID
         message: The claim type supplied is not available for this type of loss
 
+    ruleCsfhlClaimNotSupported:
+        description: |
+          carry-sideways-fhl claim for income sources "FHL Property - EEA" and "UK Property FHL" will not be supported from tax year 25/26.
+        value:
+          code: RULE_CSFHL_CLAIM_NOT_SUPPORTED
+          message: carry-sideways-fhl claim for income sources foreign-property-fhl-eea and uk-property-fhl will not be supported from tax year 25/26
+
     ruleNoChangeBroughtForward:
       description: |
         The loss amount supplied is the same as the existing stored loss amount.

--- a/resources/public/api/conf/5.0/loss_claims_amend_type.yaml
+++ b/resources/public/api/conf/5.0/loss_claims_amend_type.yaml
@@ -4,6 +4,10 @@ post:
     This endpoint allows a developer to change the type of claim for an existing loss claim type.
     A National Insurance Number and Claim ID must be provided.
     
+    <strong>
+      Note: carry-sideways-fhl type of loss claims for income sources uk-property-fhl and foreign-property-fhl-eea will not be supported from tax year 2025-26 onwards.
+    </strong>
+    
     ### Test data
     Scenario simulation using Gov-Test-Scenario headers is only available in the sandbox environment.
     
@@ -12,14 +16,15 @@ post:
     | N/A - DEFAULT                    | Simulates success response.                                                                                                                            |
     | FP_FORWARD                       | Simulates a Foreign Property carried forward scenario.                                                                                                 |
     | FP_SIDEWAYS                      | Simulates a Foreign Property carried sideways scenario.                                                                                                |
-    | NONFHL_FORWARD                   | Simulates a Non-FHL carried forward scenario.                                                                                                          |
-    | NONFHL_FORWARD_TO_SIDEWAYS       | Simulates a Non-FHL carried forward to sideways scenario.                                                                                              |
-    | NONFHL_SIDEWAYS                  | Simulates a Non-FHL carried sideways scenario.                                                                                                         |
-    | NONFHL_SIDEWAYS_FHL              | Simulates a FHL carried sideways scenario.                                                                                                             |
+    | UK_FORWARD                       | Simulates a UK Property (Non-FHL) carried forward scenario.                                                                                                          |
+    | UK_FORWARD_TO_SIDEWAYS           | Simulates a UK Property (Non-FHL) carried forward to sideways scenario.                                                                                              |
+    | UK_SIDEWAYS                      | Simulates a UK Property (Non-FHL) carried sideways scenario.                                                                                                         |
+    | UK_SIDEWAYS_FHL                  | Simulates a UK Property FHL carried sideways scenario.                                                                                                             |
     | SE_FORWARD                       | Simulates a Self Employment carried forward scenario.                                                                                                  |
     | SE_SIDEWAYS                      | Simulates a Self Employment carried sideways scenario.                                                                                                 |
     | NO_CHANGE                        | Simulates the scenario where the relief type has not changed.                                                                                          |
-    | TYPE_OF_CLAIM_INVALID            | Simulates the scenario where a claim type is invalid for the income source.                                                                            |
+    | TYPE_OF_CLAIM_INVALID            | Simulates the scenario where a claim type is invalid for the income source.                                                                            |         
+    | CSFHL_CLAIM_NOT_SUPPORTED        | Simulates the scenario where carry-sideways-fhl claim submitted for income sources "FHL Property - EEA" and "UK Property FHL".                         |
     | NOT_FOUND                        | Simulates the scenario where no data is found.                                                                                                         |
     | STATEFUL                         | Performs a stateful update.                                                                                                                            |
     | DYNAMIC                          | The following response values will change to correspond to the values submitted in the request:<br> • typeOfClaim<br> •  typeOfLoss<br> • lastModified |
@@ -86,6 +91,8 @@ post:
               $ref: './common/errors.yaml#/components/examples/formatTypeOfClaim'
             RULE_TYPE_OF_CLAIM_INVALID:
               $ref: './common/errors.yaml#/components/examples/ruleTypeOfClaimInvalid'
+            RULE_CSFHL_CLAIM_NOT_SUPPORTED:
+                $ref: './common/errors.yaml#/components/examples/ruleCsfhlClaimNotSupported'
             RULE_NO_CHANGE:
               $ref: './common/errors.yaml#/components/examples/ruleNoChangeLossClaim'
             RULE_INCORRECT_GOV_TEST_SCENARIO:

--- a/test/v5/bfLosses/list/def1/model/response/Def1_ListBFLossesResponseSpec.scala
+++ b/test/v5/bfLosses/list/def1/model/response/Def1_ListBFLossesResponseSpec.scala
@@ -19,7 +19,6 @@ package v5.bfLosses.list.def1.model.response
 import play.api.libs.json.Json
 import shared.utils.UnitSpec
 import v5.bfLosses.common.domain.TypeOfLoss
-import v5.bfLosses.list.def1.model.response.{Def1_ListBFLossesResponse, ListBFLossesItem}
 
 class Def1_ListBFLossesResponseSpec extends UnitSpec {
 

--- a/test/v5/lossClaims/amendType/AmendLossClaimTypeServiceSpec.scala
+++ b/test/v5/lossClaims/amendType/AmendLossClaimTypeServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package v5.lossClaims.amendType
 
-import common.errors.{ClaimIdFormatError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
+import common.errors.{ClaimIdFormatError, RuleCSFHLClaimNotSupportedError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
 import shared.models.domain.{Nino, Timestamp}
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
@@ -89,6 +89,7 @@ class AmendLossClaimTypeServiceSpec extends ServiceSpec {
         "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
         "INVALID_PAYLOAD"           -> InternalError,
         "INVALID_CLAIM_TYPE"        -> RuleTypeOfClaimInvalid,
+        "CSFHL_CLAIM_NOT_SUPPORTED" -> RuleCSFHLClaimNotSupportedError,
         "NOT_FOUND"                 -> NotFoundError,
         "CONFLICT"                  -> RuleClaimTypeNotChanged,
         "INVALID_CORRELATIONID"     -> InternalError,


### PR DESCRIPTION
- Add `RULE_CSFHL_CLAIM_NOT_SUPPORTED` for AmendLossClaimType on V5 endpoints ready for use in Tax year 2025-26
- Remove mentions to Non FHL in OAS