### PR TITLE
[MTDSA-27904]: Add rule OUTSIDE_AMENDMENT_WINDOW

### DIFF
--- a/app/common/errors/LossesApiCommonErrors.scala
+++ b/app/common/errors/LossesApiCommonErrors.scala
@@ -57,3 +57,5 @@ object RuleBflNotSupportedForFhlProperties
       "RULE_BFL_NOT_SUPPORTED_FOR_FHL_PROPERTIES",
       "Brought forward losses for income sources uk-property-fhl and foreign-property-fhl-eea are not supported from tax year 25/26",
       BAD_REQUEST)
+
+object RuleOutsideAmendmentWindow extends MtdError("RULE_OUTSIDE_AMENDMENT_WINDOW", "You are outside the amendment window", BAD_REQUEST)

--- a/app/v6/bfLosses/amend/AmendBFLossService.scala
+++ b/app/v6/bfLosses/amend/AmendBFLossService.scala
@@ -20,7 +20,7 @@ import shared.controllers.RequestContext
 import shared.models.errors._
 import shared.services.{BaseService, ServiceOutcome}
 import cats.implicits._
-import common.errors.{LossIdFormatError, RuleLossAmountNotChanged}
+import common.errors.{LossIdFormatError, RuleLossAmountNotChanged, RuleOutsideAmendmentWindow}
 import v6.bfLosses.amend
 import v6.bfLosses.amend.model.request.AmendBFLossRequestData
 import v6.bfLosses.amend.model.response.AmendBFLossResponse
@@ -41,6 +41,7 @@ class AmendBFLossService @Inject() (connector: amend.AmendBFLossConnector) exten
       "INVALID_LOSS_ID"           -> LossIdFormatError,
       "NOT_FOUND"                 -> NotFoundError,
       "CONFLICT"                  -> RuleLossAmountNotChanged,
+      "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
       "INVALID_CORRELATIONID"     -> InternalError,
       "INVALID_PAYLOAD"           -> InternalError,
       "SERVER_ERROR"              -> InternalError,

--- a/app/v6/bfLosses/create/CreateBFLossService.scala
+++ b/app/v6/bfLosses/create/CreateBFLossService.scala
@@ -17,7 +17,7 @@
 package v6.bfLosses.create
 
 import cats.implicits._
-import common.errors.{RuleBflNotSupportedForFhlProperties, RuleDuplicateSubmissionError}
+import common.errors.{RuleBflNotSupportedForFhlProperties, RuleDuplicateSubmissionError, RuleOutsideAmendmentWindow}
 import shared.controllers.RequestContext
 import shared.models.errors._
 import shared.services.{BaseService, ServiceOutcome}
@@ -42,6 +42,7 @@ class CreateBFLossService @Inject() (connector: CreateBFLossConnector) extends B
     case "INCOME_SOURCE_NOT_FOUND"              => NotFoundError
     case "TAX_YEAR_NOT_ENDED"                   => RuleTaxYearNotEndedError
     case "BFL_NOT_SUPPORTED_FOR_FHL_PROPERTIES" => RuleBflNotSupportedForFhlProperties
+    case "OUTSIDE_AMENDMENT_WINDOW"             => RuleOutsideAmendmentWindow
     case "INVALID_CORRELATIONID"                => InternalError
     case "INVALID_PAYLOAD"                      => InternalError
     case "SERVER_ERROR"                         => InternalError

--- a/app/v6/bfLosses/delete/DeleteBFLossService.scala
+++ b/app/v6/bfLosses/delete/DeleteBFLossService.scala
@@ -17,7 +17,7 @@
 package v6.bfLosses.delete
 
 import cats.implicits._
-import common.errors.{LossIdFormatError, RuleDeleteAfterFinalDeclarationError}
+import common.errors.{LossIdFormatError, RuleDeleteAfterFinalDeclarationError, RuleOutsideAmendmentWindow}
 import shared.controllers.RequestContext
 import shared.models.errors._
 import shared.services.{BaseService, ServiceOutcome}
@@ -38,6 +38,7 @@ class DeleteBFLossService @Inject() (connector: DeleteBFLossConnector) extends B
     "INVALID_LOSS_ID"           -> LossIdFormatError,
     "NOT_FOUND"                 -> NotFoundError,
     "CONFLICT"                  -> RuleDeleteAfterFinalDeclarationError,
+    "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
     "SERVER_ERROR"              -> InternalError,
     "SERVICE_UNAVAILABLE"       -> InternalError
   )

--- a/app/v6/lossClaims/amendOrder/AmendLossClaimsOrderService.scala
+++ b/app/v6/lossClaims/amendOrder/AmendLossClaimsOrderService.scala
@@ -48,6 +48,7 @@ class AmendLossClaimsOrderService @Inject() (connector: AmendLossClaimsOrderConn
     "NO_FULL_LIST"              -> RuleLossClaimsMissing,
     "CLAIM_NOT_FOUND"           -> NotFoundError,
     "TAX_YEAR_NOT_SUPPORTED"    -> RuleTaxYearNotSupportedError,
+    "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
     "SERVER_ERROR"              -> InternalError,
     "SERVICE_UNAVAILABLE"       -> InternalError
   )

--- a/app/v6/lossClaims/amendType/AmendLossClaimTypeService.scala
+++ b/app/v6/lossClaims/amendType/AmendLossClaimTypeService.scala
@@ -17,7 +17,13 @@
 package v6.lossClaims.amendType
 
 import cats.implicits._
-import common.errors.{ClaimIdFormatError, RuleCSFHLClaimNotSupportedError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
+import common.errors.{
+  ClaimIdFormatError,
+  RuleCSFHLClaimNotSupportedError,
+  RuleClaimTypeNotChanged,
+  RuleOutsideAmendmentWindow,
+  RuleTypeOfClaimInvalid
+}
 import shared.controllers.RequestContext
 import shared.models.errors._
 import shared.services.{BaseService, ServiceOutcome}
@@ -44,6 +50,7 @@ class AmendLossClaimTypeService @Inject() (connector: AmendLossClaimTypeConnecto
     "CSFHL_CLAIM_NOT_SUPPORTED" -> RuleCSFHLClaimNotSupportedError,
     "NOT_FOUND"                 -> NotFoundError,
     "CONFLICT"                  -> RuleClaimTypeNotChanged,
+    "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
     "INVALID_CORRELATIONID"     -> InternalError,
     "SERVER_ERROR"              -> InternalError,
     "SERVICE_UNAVAILABLE"       -> InternalError

--- a/app/v6/lossClaims/create/CreateLossClaimService.scala
+++ b/app/v6/lossClaims/create/CreateLossClaimService.scala
@@ -21,6 +21,7 @@ import common.errors.{
   RuleCSFHLClaimNotSupportedError,
   RuleDuplicateClaimSubmissionError,
   RuleNoAccountingPeriod,
+  RuleOutsideAmendmentWindow,
   RulePeriodNotEnded,
   RuleTypeOfClaimInvalid
 }
@@ -54,6 +55,7 @@ class CreateLossClaimService @Inject() (connector: CreateLossClaimConnector) ext
     case "SERVICE_UNAVAILABLE"         => InternalError
     case "INVALID_CORRELATIONID"       => InternalError
     case "CSFHL_CLAIM_NOT_SUPPORTED"   => RuleCSFHLClaimNotSupportedError
+    case "OUTSIDE_AMENDMENT_WINDOW"    => RuleOutsideAmendmentWindow
   }
 
 }

--- a/app/v6/lossClaims/delete/DeleteLossClaimService.scala
+++ b/app/v6/lossClaims/delete/DeleteLossClaimService.scala
@@ -17,7 +17,7 @@
 package v6.lossClaims.delete
 
 import cats.implicits._
-import common.errors.ClaimIdFormatError
+import common.errors.{ClaimIdFormatError, RuleOutsideAmendmentWindow}
 import shared.controllers.RequestContext
 import shared.models.errors._
 import shared.services.{BaseService, ServiceOutcome}
@@ -37,6 +37,7 @@ class DeleteLossClaimService @Inject() (connector: DeleteLossClaimConnector) ext
     "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
     "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
     "NOT_FOUND"                 -> NotFoundError,
+    "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
     "SERVER_ERROR"              -> InternalError,
     "SERVICE_UNAVAILABLE"       -> InternalError
   )

--- a/it/v5/bfLosses/amend/def1/Def1_AmendBFLossControllerISpec.scala
+++ b/it/v5/bfLosses/amend/def1/Def1_AmendBFLossControllerISpec.scala
@@ -180,4 +180,5 @@ class Def1_AmendBFLossControllerISpec extends IntegrationBaseSpec {
       }
     }
   }
+
 }

--- a/it/v6/bfLosses/amend/def1/Def1_AmendBFLossControllerISpec.scala
+++ b/it/v6/bfLosses/amend/def1/Def1_AmendBFLossControllerISpec.scala
@@ -17,7 +17,7 @@
 package v6.bfLosses.amend.def1
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import common.errors.{LossIdFormatError, RuleLossAmountNotChanged}
+import common.errors.{LossIdFormatError, RuleLossAmountNotChanged, RuleOutsideAmendmentWindow}
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status
 import play.api.http.Status._
@@ -87,7 +87,7 @@ class Def1_AmendBFLossControllerISpec extends IntegrationBaseSpec {
       setupStubs()
       buildRequest(url)
         .withHttpHeaders(
-          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (ACCEPT, "application/vnd.hmrc.6.0+json"),
           (AUTHORIZATION, "Bearer 123")
         )
     }
@@ -170,6 +170,7 @@ class Def1_AmendBFLossControllerISpec extends IntegrationBaseSpec {
           (BAD_REQUEST, "INVALID_LOSS_ID", BAD_REQUEST, LossIdFormatError),
           (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
           (CONFLICT, "CONFLICT", BAD_REQUEST, RuleLossAmountNotChanged),
+          (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindow),
           (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
           (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
           (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
@@ -180,4 +181,5 @@ class Def1_AmendBFLossControllerISpec extends IntegrationBaseSpec {
       }
     }
   }
+
 }

--- a/it/v6/bfLosses/create/def1/Def1_CreateBFLossControllerISpec.scala
+++ b/it/v6/bfLosses/create/def1/Def1_CreateBFLossControllerISpec.scala
@@ -17,7 +17,7 @@
 package v6.bfLosses.create.def1
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import common.errors.{RuleBflNotSupportedForFhlProperties, RuleDuplicateSubmissionError, TypeOfLossFormatError}
+import common.errors.{RuleBflNotSupportedForFhlProperties, RuleDuplicateSubmissionError, RuleOutsideAmendmentWindow, TypeOfLossFormatError}
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status._
 import play.api.libs.json._
@@ -173,6 +173,7 @@ class Def1_CreateBFLossControllerISpec extends IntegrationBaseSpec with JsonErro
         serviceErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
         serviceErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
         serviceErrorTest(UNPROCESSABLE_ENTITY, "BFL_NOT_SUPPORTED_FOR_FHL_PROPERTIES", BAD_REQUEST, RuleBflNotSupportedForFhlProperties)
+        serviceErrorTest(UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindow)
       }
     }
   }

--- a/it/v6/bfLosses/delete/def1/Def1_DeleteBFLossControllerISpec.scala
+++ b/it/v6/bfLosses/delete/def1/Def1_DeleteBFLossControllerISpec.scala
@@ -17,7 +17,7 @@
 package v6.bfLosses.delete.def1
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import common.errors.{LossIdFormatError, RuleDeleteAfterFinalDeclarationError}
+import common.errors.{LossIdFormatError, RuleDeleteAfterFinalDeclarationError, RuleOutsideAmendmentWindow}
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}
@@ -101,6 +101,7 @@ class Def1_DeleteBFLossControllerISpec extends IntegrationBaseSpec {
       serviceErrorTest(BAD_REQUEST, "UNEXPECTED_DES_ERROR_CODE", INTERNAL_SERVER_ERROR, InternalError)
       serviceErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
       serviceErrorTest(CONFLICT, "CONFLICT", BAD_REQUEST, RuleDeleteAfterFinalDeclarationError)
+      serviceErrorTest(UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindow)
       serviceErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
       serviceErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
     }

--- a/it/v6/lossClaim/amendOrder/def1/Def1_AmendLossClaimsOrderISpec.scala
+++ b/it/v6/lossClaim/amendOrder/def1/Def1_AmendLossClaimsOrderISpec.scala
@@ -145,6 +145,7 @@ class Def1_AmendLossClaimsOrderISpec extends IntegrationBaseSpec {
         (CONFLICT, "SEQUENCE_START", BAD_REQUEST, RuleInvalidSequenceStart),
         (CONFLICT, "NO_FULL_LIST", BAD_REQUEST, RuleLossClaimsMissing),
         (NOT_FOUND, "CLAIM_NOT_FOUND", NOT_FOUND, NotFoundError),
+        (UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindow),
         (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
         (Status.INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
         (Status.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)

--- a/it/v6/lossClaim/amendType/def1/Def1_AmendLossClaimTypeISpec.scala
+++ b/it/v6/lossClaim/amendType/def1/Def1_AmendLossClaimTypeISpec.scala
@@ -132,6 +132,7 @@ class Def1_AmendLossClaimTypeISpec extends IntegrationBaseSpec {
       serviceErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
       serviceErrorTest(UNPROCESSABLE_ENTITY, "INVALID_CLAIM_TYPE", BAD_REQUEST, RuleTypeOfClaimInvalid)
       serviceErrorTest(UNPROCESSABLE_ENTITY, "CSFHL_CLAIM_NOT_SUPPORTED", BAD_REQUEST, RuleCSFHLClaimNotSupportedError)
+      serviceErrorTest(UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindow)
       serviceErrorTest(CONFLICT, "CONFLICT", BAD_REQUEST, RuleClaimTypeNotChanged)
       serviceErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
       serviceErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)

--- a/it/v6/lossClaim/create/def1/Def1_CreateLossClaimISpec.scala
+++ b/it/v6/lossClaim/create/def1/Def1_CreateLossClaimISpec.scala
@@ -124,6 +124,7 @@ class Def1_CreateLossClaimISpec extends IntegrationBaseSpec {
       createErrorTest(UNPROCESSABLE_ENTITY, "ACCOUNTING_PERIOD_NOT_ENDED", BAD_REQUEST, RulePeriodNotEnded)
       createErrorTest(UNPROCESSABLE_ENTITY, "NO_ACCOUNTING_PERIOD", BAD_REQUEST, RuleNoAccountingPeriod)
       createErrorTest(UNPROCESSABLE_ENTITY, "CSFHL_CLAIM_NOT_SUPPORTED", BAD_REQUEST, RuleCSFHLClaimNotSupportedError)
+      createErrorTest(UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", BAD_REQUEST, RuleOutsideAmendmentWindow)
     }
 
     "return 404 NOT FOUND" when {

--- a/it/v6/lossClaim/delete/def1/Def1_DeleteLossClaimISpec.scala
+++ b/it/v6/lossClaim/delete/def1/Def1_DeleteLossClaimISpec.scala
@@ -18,7 +18,7 @@ package v6.lossClaim.delete.def1
 
 import shared.models.errors._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import common.errors.ClaimIdFormatError
+import common.errors.{ClaimIdFormatError, RuleOutsideAmendmentWindow}
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status
 import play.api.libs.json.{JsObject, Json}
@@ -100,6 +100,7 @@ class Def1_DeleteLossClaimISpec extends IntegrationBaseSpec {
       serviceErrorTest(Status.BAD_REQUEST, "INVALID_CLAIM_ID", Status.BAD_REQUEST, ClaimIdFormatError)
       serviceErrorTest(Status.BAD_REQUEST, "UNEXPECTED_DES_ERROR_CODE", Status.INTERNAL_SERVER_ERROR, InternalError)
       serviceErrorTest(Status.NOT_FOUND, "NOT_FOUND", Status.NOT_FOUND, NotFoundError)
+      serviceErrorTest(Status.UNPROCESSABLE_ENTITY, "OUTSIDE_AMENDMENT_WINDOW", Status.BAD_REQUEST, RuleOutsideAmendmentWindow)
       serviceErrorTest(Status.INTERNAL_SERVER_ERROR, "SERVER_ERROR", Status.INTERNAL_SERVER_ERROR, InternalError)
       serviceErrorTest(Status.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", Status.INTERNAL_SERVER_ERROR, InternalError)
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.22.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.0")
 addSbtPlugin("org.scalastyle"    % "scalastyle-sbt-plugin" % "1.0.0" exclude ("org.scala-lang.modules", "scala-xml_2.12"))

--- a/resources/public/api/conf/6.0/brought_forward_losses_amend.yaml
+++ b/resources/public/api/conf/6.0/brought_forward_losses_amend.yaml
@@ -25,6 +25,7 @@ post:
     | UK_PROPERTY                       | Simulates the scenario where type of loss is UK Property (Non-FHL).                                                                 |
     | NOT_FOUND                         | Simulates the scenario where no data is found.                                                                                      |
     | NO_CHANGE                         | Simulates the scenario where the brought forward loss amount has not changed.                                                       |
+    | OUTSIDE_AMENDMENT_WINDOW          | Simulates the scenario where request cannot be completed as it is outside the amendment window.                                     |
     | DYNAMIC                           | The following response values will change to correspond to the values submitted in the request:<br> • lossAmount<br> • lastModified |
     | STATEFUL                          | Performs a stateful update.                                                                                                         |
 
@@ -93,6 +94,8 @@ post:
               $ref: './common/errors.yaml#/components/examples/ruleNoChangeBroughtForward'
             RULE_INCORRECT_GOV_TEST_SCENARIO:
               $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
+            RULE_OUTSIDE_AMENDMENT_WINDOW:
+              $ref: './common/errors.yaml#/components/examples/ruleOutsideAmendmentWindow'
 
     "403":
       description: Forbidden

--- a/resources/public/api/conf/6.0/brought_forward_losses_create.yaml
+++ b/resources/public/api/conf/6.0/brought_forward_losses_create.yaml
@@ -21,6 +21,7 @@ post:
     | DUPLICATE_SUBMISSION                 | Simulates the scenario where a duplicated loss is found.                                                                                             |
     | STATEFUL                             | Performs a stateful create.                                                                                                                          |
     | BFL_NOT_SUPPORTED_FOR_FHL_PROPERTIES | Simulates the scenario where brought forward losses are submitted for income sources uk-property-fhl or foreign-property-fhl-eea for tax year 25/26. |
+    | OUTSIDE_AMENDMENT_WINDOW             | Simulates the scenario where request cannot be completed as it is outside the amendment window.                                                      |
 
   tags:
     - Brought Forward Losses
@@ -103,6 +104,8 @@ post:
               $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
             RULE_BFL_NOT_SUPPORTED_FOR_FHL_PROPERTIES:
               $ref: './common/errors.yaml#/components/examples/ruleBflNotSupportedForFhlProperties'
+            RULE_OUTSIDE_AMENDMENT_WINDOW:
+              $ref: './common/errors.yaml#/components/examples/ruleOutsideAmendmentWindow'
 
     "403":
       description: Forbidden

--- a/resources/public/api/conf/6.0/brought_forward_losses_delete.yaml
+++ b/resources/public/api/conf/6.0/brought_forward_losses_delete.yaml
@@ -11,6 +11,7 @@ description: |
   | N/A - DEFAULT                          | Simulates success response.                    |
   | DELETE_AFTER_FINAL_DECLARATION         | Simulates the error scenario where the user has already submitted a final declaration for this tax year. |
   | NOT_FOUND                              | Simulates the scenario where no data is found. |
+  | OUTSIDE_AMENDMENT_WINDOW               | Simulates the scenario where request cannot be completed as it is outside the amendment window. |
   | STATEFUL                               | Performs a stateful delete.                    |
 
 tags:
@@ -52,6 +53,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleDeleteAfterFinalDeclaration'
           RULE_INCORRECT_GOV_TEST_SCENARIO:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
+          RULE_OUTSIDE_AMENDMENT_WINDOW:
+            $ref: './common/errors.yaml#/components/examples/ruleOutsideAmendmentWindow'
 
   "403":
     description: Forbidden

--- a/resources/public/api/conf/6.0/common/errors.yaml
+++ b/resources/public/api/conf/6.0/common/errors.yaml
@@ -192,6 +192,13 @@ components:
       value:
         code: RULE_BFL_NOT_SUPPORTED_FOR_FHL_PROPERTIES
         message: Brought forward losses for income sources uk-property-fhl and foreign-property-fhl-eea are not supported from tax year 25/26
+        
+    ruleOutsideAmendmentWindow:
+      description: |
+        The request cannot be completed as you are outside the amendment window.
+      value: 
+        code: RULE_OUTSIDE_AMENDMENT_WINDOW
+        message: You are outside the amendment window
 
     # 403
 

--- a/resources/public/api/conf/6.0/loss_claims_amend_order.yaml
+++ b/resources/public/api/conf/6.0/loss_claims_amend_order.yaml
@@ -11,6 +11,7 @@ description: |
   | N/A - DEFAULT                    | Simulates success response.                                                           |
   | LOSS_CLAIMS_MISSING              | Simulates the scenario where not all claims of the given type and year were included. |
   | NOT_FOUND                        | Simulates the scenario where one or more claims were not found.                       |
+  | OUTSIDE_AMENDMENT_WINDOW         | Simulates the scenario where request cannot be completed as it is outside the amendment window. |
   | STATEFUL                         | Performs a stateful update.                                                           |
 
 
@@ -79,6 +80,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectOrEmptyBody'
           RULE_INCORRECT_GOV_TEST_SCENARIO:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
+          RULE_OUTSIDE_AMENDMENT_WINDOW:
+            $ref: './common/errors.yaml#/components/examples/ruleOutsideAmendmentWindow'
 
   "403":
     description: Forbidden

--- a/resources/public/api/conf/6.0/loss_claims_amend_type.yaml
+++ b/resources/public/api/conf/6.0/loss_claims_amend_type.yaml
@@ -16,16 +16,17 @@ post:
     | N/A - DEFAULT                    | Simulates success response.                                                                                                                            |
     | FP_FORWARD                       | Simulates a Foreign Property carried forward scenario.                                                                                                 |
     | FP_SIDEWAYS                      | Simulates a Foreign Property carried sideways scenario.                                                                                                |
-    | UK_FORWARD                       | Simulates a UK Property (Non-FHL) carried forward scenario.                                                                                                          |
-    | UK_FORWARD_TO_SIDEWAYS           | Simulates a UK Property (Non-FHL) carried forward to sideways scenario.                                                                                              |
-    | UK_SIDEWAYS                      | Simulates a UK Property (Non-FHL) carried sideways scenario.                                                                                                         |
-    | UK_SIDEWAYS_FHL                  | Simulates a UK Property FHL carried sideways scenario.                                                                                                             |
+    | UK_FORWARD                       | Simulates a UK Property (Non-FHL) carried forward scenario.                                                                                            |
+    | UK_FORWARD_TO_SIDEWAYS           | Simulates a UK Property (Non-FHL) carried forward to sideways scenario.                                                                                |
+    | UK_SIDEWAYS                      | Simulates a UK Property (Non-FHL) carried sideways scenario.                                                                                           |
+    | UK_SIDEWAYS_FHL                  | Simulates a UK Property FHL carried sideways scenario.                                                                                                 |
     | SE_FORWARD                       | Simulates a Self Employment carried forward scenario.                                                                                                  |
     | SE_SIDEWAYS                      | Simulates a Self Employment carried sideways scenario.                                                                                                 |
     | NO_CHANGE                        | Simulates the scenario where the relief type has not changed.                                                                                          |
     | TYPE_OF_CLAIM_INVALID            | Simulates the scenario where a claim type is invalid for the income source.                                                                            |         
     | CSFHL_CLAIM_NOT_SUPPORTED        | Simulates the scenario where carry-sideways-fhl claim submitted for income sources "FHL Property - EEA" and "UK Property FHL".                         |
     | NOT_FOUND                        | Simulates the scenario where no data is found.                                                                                                         |
+    | OUTSIDE_AMENDMENT_WINDOW         | Simulates the scenario where request cannot be completed as it is outside the amendment window.                                                        |
     | STATEFUL                         | Performs a stateful update.                                                                                                                            |
     | DYNAMIC                          | The following response values will change to correspond to the values submitted in the request:<br> • typeOfClaim<br> •  typeOfLoss<br> • lastModified |
 
@@ -97,6 +98,8 @@ post:
               $ref: './common/errors.yaml#/components/examples/ruleNoChangeLossClaim'
             RULE_INCORRECT_GOV_TEST_SCENARIO:
               $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
+            RULE_OUTSIDE_AMENDMENT_WINDOW:
+              $ref: './common/errors.yaml#/components/examples/ruleOutsideAmendmentWindow'
 
 
     "403":

--- a/resources/public/api/conf/6.0/loss_claims_create.yaml
+++ b/resources/public/api/conf/6.0/loss_claims_create.yaml
@@ -18,6 +18,7 @@ post:
     | DUPLICATE                        | Simulates the scenario where a duplicated value is found.                             |
     | ACCOUNTING_PERIOD_NOT_ENDED      | Simulates the scenario where the loss claim has been made too soon.                   |
     | NO_ACCOUNTING_PERIOD             | Simulates the scenario where there is no accounting period for the year of the claim. |
+    | OUTSIDE_AMENDMENT_WINDOW         | Simulates the scenario where request cannot be completed as it is outside the amendment window. |
     | STATEFUL                         | Performs a stateful create.                                                           |
     | CSFHL_CLAIM_NOT_SUPPORTED        | Simulates the scenario where carry-sideways-fhl claim submitted for income sources "FHL Property - EEA" and "UK Property FHL".|
 
@@ -106,6 +107,8 @@ post:
               $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
             RULE_CSFHL_CLAIM_NOT_SUPPORTED:
               $ref: './common/errors.yaml#/components/examples/ruleCsfhlClaimNotSupported'
+            RULE_OUTSIDE_AMENDMENT_WINDOW:
+              $ref: './common/errors.yaml#/components/examples/ruleOutsideAmendmentWindow'
 
     "403":
       description: Forbidden

--- a/resources/public/api/conf/6.0/loss_claims_delete.yaml
+++ b/resources/public/api/conf/6.0/loss_claims_delete.yaml
@@ -10,6 +10,7 @@ description: |
   | -------------------------------- | ---------------------------------------------- |
   | N/A - DEFAULT                    | Simulate success scenario                      |
   | NOT_FOUND                        | Simulates the scenario where no data is found. |
+  | OUTSIDE_AMENDMENT_WINDOW         | Simulates the scenario where request cannot be completed as it is outside the amendment window. |
   | STATEFUL                         | Performs a stateful delete.                    |
 
 
@@ -49,6 +50,8 @@ responses:
             $ref: './common/errors.yaml#/components/examples/formatClaimId'
           RULE_INCORRECT_GOV_TEST_SCENARIO:
             $ref: './common/errors.yaml#/components/examples/ruleIncorrectGovTestScenario'
+          RULE_OUTSIDE_AMENDMENT_WINDOW:
+            $ref: './common/errors.yaml#/components/examples/ruleOutsideAmendmentWindow'
 
   "403":
     description: Forbidden

--- a/test/v6/bfLosses/amend/AmendBFLossServiceSpec.scala
+++ b/test/v6/bfLosses/amend/AmendBFLossServiceSpec.scala
@@ -16,13 +16,12 @@
 
 package v6.bfLosses.amend
 
-import common.errors.{LossIdFormatError, RuleLossAmountNotChanged}
+import common.errors.{LossIdFormatError, RuleLossAmountNotChanged, RuleOutsideAmendmentWindow}
 import shared.models.domain.{Nino, Timestamp}
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
 import shared.services.ServiceSpec
 import v6.bfLosses.amend
-import v6.bfLosses.amend.AmendBFLossService
 import v6.bfLosses.amend.def1.model.request.{Def1_AmendBFLossRequestBody, Def1_AmendBFLossRequestData}
 import v6.bfLosses.amend.def1.model.response.Def1_AmendBFLossResponse
 import v6.bfLosses.common.domain.{LossId, TypeOfLoss}
@@ -82,6 +81,7 @@ class AmendBFLossServiceSpec extends ServiceSpec {
       "NOT_FOUND"                 -> NotFoundError,
       "INVALID_PAYLOAD"           -> InternalError,
       "CONFLICT"                  -> RuleLossAmountNotChanged,
+      "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
       "INVALID_CORRELATIONID"     -> InternalError,
       "SERVER_ERROR"              -> InternalError,
       "SERVICE_UNAVAILABLE"       -> InternalError,

--- a/test/v6/bfLosses/create/CreateBFLossServiceSpec.scala
+++ b/test/v6/bfLosses/create/CreateBFLossServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package v6.bfLosses.create
 
-import common.errors.{RuleBflNotSupportedForFhlProperties, RuleDuplicateSubmissionError}
+import common.errors.{RuleBflNotSupportedForFhlProperties, RuleDuplicateSubmissionError, RuleOutsideAmendmentWindow}
 import shared.models.domain.Nino
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
@@ -79,6 +79,7 @@ class CreateBFLossServiceSpec extends ServiceSpec {
         "TAX_YEAR_NOT_SUPPORTED"               -> RuleTaxYearNotSupportedError,
         "TAX_YEAR_NOT_ENDED"                   -> RuleTaxYearNotEndedError,
         "BFL_NOT_SUPPORTED_FOR_FHL_PROPERTIES" -> RuleBflNotSupportedForFhlProperties,
+        "OUTSIDE_AMENDMENT_WINDOW"             -> RuleOutsideAmendmentWindow,
         "INCOME_SOURCE_NOT_FOUND"              -> NotFoundError,
         "INVALID_CORRELATIONID"                -> InternalError,
         "INVALID_PAYLOAD"                      -> InternalError,

--- a/test/v6/bfLosses/delete/DeleteBFLossServiceSpec.scala
+++ b/test/v6/bfLosses/delete/DeleteBFLossServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package v6.bfLosses.delete
 
-import common.errors.{LossIdFormatError, RuleDeleteAfterFinalDeclarationError}
+import common.errors.{LossIdFormatError, RuleDeleteAfterFinalDeclarationError, RuleOutsideAmendmentWindow}
 import shared.models.domain.Nino
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
@@ -75,6 +75,7 @@ class DeleteBFLossServiceSpec extends ServiceSpec {
         "INVALID_LOSS_ID"           -> LossIdFormatError,
         "NOT_FOUND"                 -> NotFoundError,
         "CONFLICT"                  -> RuleDeleteAfterFinalDeclarationError,
+        "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
         "SERVER_ERROR"              -> InternalError,
         "SERVICE_UNAVAILABLE"       -> InternalError,
         "UNEXPECTED_ERROR"          -> InternalError

--- a/test/v6/lossClaims/amendOrder/AmendLossClaimsOrderServiceSpec.scala
+++ b/test/v6/lossClaims/amendOrder/AmendLossClaimsOrderServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package v6.lossClaims.amendOrder
 
-import _root_.common.errors.{RuleInvalidSequenceStart, RuleLossClaimsMissing, RuleSequenceOrderBroken}
+import _root_.common.errors.{RuleInvalidSequenceStart, RuleLossClaimsMissing, RuleOutsideAmendmentWindow, RuleSequenceOrderBroken}
 import shared.models.domain.{Nino, TaxYear}
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
@@ -85,6 +85,7 @@ class AmendLossClaimsOrderServiceSpec extends ServiceSpec {
         ("NO_FULL_LIST", RuleLossClaimsMissing),
         ("CLAIM_NOT_FOUND", NotFoundError),
         ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError),
+        ("OUTSIDE_AMENDMENT_WINDOW", RuleOutsideAmendmentWindow),
         ("INVALID_PAYLOAD", InternalError),
         ("SERVER_ERROR", InternalError),
         ("SERVICE_UNAVAILABLE", InternalError)

--- a/test/v6/lossClaims/amendType/AmendLossClaimTypeServiceSpec.scala
+++ b/test/v6/lossClaims/amendType/AmendLossClaimTypeServiceSpec.scala
@@ -16,7 +16,13 @@
 
 package v6.lossClaims.amendType
 
-import common.errors.{ClaimIdFormatError, RuleCSFHLClaimNotSupportedError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
+import common.errors.{
+  ClaimIdFormatError,
+  RuleCSFHLClaimNotSupportedError,
+  RuleClaimTypeNotChanged,
+  RuleOutsideAmendmentWindow,
+  RuleTypeOfClaimInvalid
+}
 import shared.models.domain.{Nino, Timestamp}
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
@@ -92,6 +98,7 @@ class AmendLossClaimTypeServiceSpec extends ServiceSpec {
         "CSFHL_CLAIM_NOT_SUPPORTED" -> RuleCSFHLClaimNotSupportedError,
         "NOT_FOUND"                 -> NotFoundError,
         "CONFLICT"                  -> RuleClaimTypeNotChanged,
+        "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
         "INVALID_CORRELATIONID"     -> InternalError,
         "SERVER_ERROR"              -> InternalError,
         "SERVICE_UNAVAILABLE"       -> InternalError,

--- a/test/v6/lossClaims/create/CreateLossClaimServiceSpec.scala
+++ b/test/v6/lossClaims/create/CreateLossClaimServiceSpec.scala
@@ -16,7 +16,13 @@
 
 package v6.lossClaims.create
 
-import common.errors.{RuleDuplicateClaimSubmissionError, RuleNoAccountingPeriod, RulePeriodNotEnded, RuleTypeOfClaimInvalid}
+import common.errors.{
+  RuleDuplicateClaimSubmissionError,
+  RuleNoAccountingPeriod,
+  RuleOutsideAmendmentWindow,
+  RulePeriodNotEnded,
+  RuleTypeOfClaimInvalid
+}
 import shared.models.domain.Nino
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
@@ -96,6 +102,7 @@ class CreateLossClaimServiceSpec extends ServiceSpec {
         "INCOME_SOURCE_NOT_FOUND"     -> NotFoundError,
         "TAX_YEAR_NOT_SUPPORTED"      -> RuleTaxYearNotSupportedError,
         "NO_ACCOUNTING_PERIOD"        -> RuleNoAccountingPeriod,
+        "OUTSIDE_AMENDMENT_WINDOW"    -> RuleOutsideAmendmentWindow,
         "INVALID_PAYLOAD"             -> InternalError,
         "SERVER_ERROR"                -> InternalError,
         "SERVICE_UNAVAILABLE"         -> InternalError,

--- a/test/v6/lossClaims/delete/DeleteLossClaimServiceSpec.scala
+++ b/test/v6/lossClaims/delete/DeleteLossClaimServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package v6.lossClaims.delete
 
-import common.errors.ClaimIdFormatError
+import common.errors.{ClaimIdFormatError, RuleOutsideAmendmentWindow}
 import shared.models.domain.Nino
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
@@ -80,6 +80,7 @@ class DeleteLossClaimServiceSpec extends ServiceSpec {
         "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
         "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
         "NOT_FOUND"                 -> NotFoundError,
+        "OUTSIDE_AMENDMENT_WINDOW"  -> RuleOutsideAmendmentWindow,
         "SERVER_ERROR"              -> InternalError,
         "SERVICE_UNAVAILABLE"       -> InternalError,
         "UNEXPECTED_ERROR"          -> InternalError


### PR DESCRIPTION
This PR includes the new rule `OUTSIDE_AMENDMENT_WINDOW` and also maps the error response to the vendor for the following endpoints under the individuals-losses-api:

* [MTDSA-27904]: Create a Brought Forward Loss
* [MTDSA-27905]: Update Brought Forward Loss
* [MTDSA-27906]: Delete Brought Forward Losses
* [MTDSA-27899]: Submit a claim for relief for a tax year
* [MTDSA-28180]: Amend a Loss Claim Type
* [MTDSA-27901]: Delete a Loss Claim
* [MTDSA-27903]: Amend Loss Claims Order