### PR TITLE
POC to implement downstream tax years for V4 and V5 that don't have tax years to send

### DIFF
--- a/app/v4/connectors/AmendBFLossConnector.scala
+++ b/app/v4/connectors/AmendBFLossConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import shared.config.SharedAppConfig
+import shared.models.domain.TaxYear.currentTaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v4.models.request.amendBFLosses.AmendBFLossRequestData
 import v4.models.response.amendBFLosses.AmendBFLossResponse
@@ -37,7 +38,7 @@ class AmendBFLossConnector @Inject() (val http: HttpClient, val appConfig: Share
 
     import request._
 
-    put(amendBroughtForwardLoss, IfsUri[AmendBFLossResponse](s"income-tax/brought-forward-losses/$nino/$lossId"))
+    put(amendBroughtForwardLoss, IfsUri[AmendBFLossResponse](s"income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId"))
   }
 
 }

--- a/app/v4/connectors/AmendLossClaimTypeConnector.scala
+++ b/app/v4/connectors/AmendLossClaimTypeConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import shared.config.SharedAppConfig
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v4.models.request.amendLossClaimType.AmendLossClaimTypeRequestData
 import v4.models.response.amendLossClaimType.AmendLossClaimTypeResponse
@@ -30,14 +31,15 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class AmendLossClaimTypeConnector @Inject() (val http: HttpClient, val appConfig: SharedAppConfig) extends BaseDownstreamConnector {
 
-  def amendLossClaimType(request: AmendLossClaimTypeRequestData)(implicit
+  def amendLossClaimType(request: AmendLossClaimTypeRequestData, taxYear: TaxYear)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext,
-      correlationId: String): Future[DownstreamOutcome[AmendLossClaimTypeResponse]] = {
+      correlationId: String
+  ): Future[DownstreamOutcome[AmendLossClaimTypeResponse]] = {
 
     import request._
 
-    put(amendLossClaimTypeRequestBody, IfsUri[AmendLossClaimTypeResponse](s"income-tax/claims-for-relief/$nino/$claimId"))
+    put(amendLossClaimTypeRequestBody, IfsUri[AmendLossClaimTypeResponse](s"income-tax/claims-for-relief/$nino/${taxYear.asTysDownstream}/$claimId"))
   }
 
 }

--- a/app/v4/connectors/CreateBFLossConnector.scala
+++ b/app/v4/connectors/CreateBFLossConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
 import shared.config.SharedAppConfig
+import shared.models.domain.TaxYear.currentTaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v4.models.request.createBFLosses.CreateBFLossRequestData
 import v4.models.response.createBFLosses.CreateBFLossResponse
@@ -36,7 +37,7 @@ class CreateBFLossConnector @Inject() (val http: HttpClient, val appConfig: Shar
       correlationId: String): Future[DownstreamOutcome[CreateBFLossResponse]] = {
     import request._
 
-    post(broughtForwardLoss, IfsUri[CreateBFLossResponse](s"income-tax/brought-forward-losses/$nino"))
+    post(broughtForwardLoss, IfsUri[CreateBFLossResponse](s"income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}"))
   }
 
 }

--- a/app/v4/connectors/DeleteBFLossConnector.scala
+++ b/app/v4/connectors/DeleteBFLossConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package v4.connectors
 import shared.connectors.DownstreamUri.{DesUri, HipUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
-import shared.config.{SharedAppConfig, ConfigFeatureSwitches}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.models.domain.TaxYear.currentTaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v4.models.request.deleteBFLosses.DeleteBFLossRequestData
 
@@ -35,7 +36,7 @@ class DeleteBFLossConnector @Inject() (val http: HttpClient, val appConfig: Shar
     import request._
 
     val downstreamUri = if (ConfigFeatureSwitches().isEnabled("des_hip_migration_1504")) {
-      HipUri[Unit](s"itsa/income-tax/v1/brought-forward-losses/$nino/$lossId")
+      HipUri[Unit](s"itsa/income-tax/v1/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId")
     } else {
       DesUri[Unit](s"income-tax/brought-forward-losses/$nino/$lossId")
     }

--- a/app/v4/connectors/DeleteLossClaimConnector.scala
+++ b/app/v4/connectors/DeleteLossClaimConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package v4.connectors
 import shared.connectors.DownstreamUri.{DesUri, HipUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
-import shared.config.{SharedAppConfig, ConfigFeatureSwitches}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v4.models.request.deleteLossClaim.DeleteLossClaimRequestData
 
@@ -29,15 +30,16 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class DeleteLossClaimConnector @Inject() (val http: HttpClient, val appConfig: SharedAppConfig) extends BaseDownstreamConnector {
 
-  def deleteLossClaim(request: DeleteLossClaimRequestData)(implicit
+  def deleteLossClaim(request: DeleteLossClaimRequestData, taxYear: TaxYear)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext,
-      correlationId: String): Future[DownstreamOutcome[Unit]] = {
+      correlationId: String
+  ): Future[DownstreamOutcome[Unit]] = {
 
     import request._
 
     val downstreamUri = if (ConfigFeatureSwitches().isEnabled("des_hip_migration_1509")) {
-      HipUri[Unit](s"itsa/income-tax/v1/claims-for-relief/$nino/$claimId")
+      HipUri[Unit](s"itsa/income-tax/v1/claims-for-relief/$nino/${taxYear.asTysDownstream}/$claimId")
     } else {
       DesUri[Unit](s"income-tax/claims-for-relief/$nino/$claimId")
     }

--- a/app/v4/services/AmendLossClaimTypeService.scala
+++ b/app/v4/services/AmendLossClaimTypeService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,23 +19,38 @@ package v4.services
 import cats.implicits._
 import common.errors.{ClaimIdFormatError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
 import shared.controllers.RequestContext
+import shared.models.domain.TaxYear
 import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
 import shared.services.{BaseService, ServiceOutcome}
-import v4.connectors.AmendLossClaimTypeConnector
+import v4.connectors.{AmendLossClaimTypeConnector, RetrieveLossClaimConnector}
 import v4.models.request.amendLossClaimType.AmendLossClaimTypeRequestData
+import v4.models.request.retrieveLossClaim.RetrieveLossClaimRequestData
 import v4.models.response.amendLossClaimType.AmendLossClaimTypeResponse
+import v4.models.response.retrieveLossClaim.RetrieveLossClaimResponse
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AmendLossClaimTypeService @Inject() (connector: AmendLossClaimTypeConnector) extends BaseService {
+class AmendLossClaimTypeService @Inject() (retrieveConnector: RetrieveLossClaimConnector, amendConnector: AmendLossClaimTypeConnector)
+    extends BaseService {
 
   def amendLossClaimType(request: AmendLossClaimTypeRequestData)(implicit
       ctx: RequestContext,
-      ec: ExecutionContext): Future[ServiceOutcome[AmendLossClaimTypeResponse]] =
-    connector
-      .amendLossClaimType(request)
-      .map(_.leftMap(mapDownstreamErrors(errorMap)))
+      ec: ExecutionContext): Future[ServiceOutcome[AmendLossClaimTypeResponse]] = {
+    val retrieveRequest: RetrieveLossClaimRequestData = RetrieveLossClaimRequestData(request.nino, request.claimId)
+
+    for {
+      retrieveResult <- retrieveConnector.retrieveLossClaim(request = retrieveRequest, isAmendRequest = true)
+      amendResult <- retrieveResult match {
+        case Right(ResponseWrapper(_, response: RetrieveLossClaimResponse)) =>
+          val taxYear: TaxYear = TaxYear.fromMtd(response.taxYearClaimedFor)
+          amendConnector.amendLossClaimType(request, taxYear).map(_.leftMap(mapDownstreamErrors(errorMap)))
+
+        case Left(error) => Future.successful(Left(mapDownstreamErrors(errorMap)(error)))
+      }
+    } yield amendResult
+  }
 
   private val errorMap: Map[String, MtdError] = Map(
     "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,

--- a/app/v4/services/DeleteLossClaimService.scala
+++ b/app/v4/services/DeleteLossClaimService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,35 @@ package v4.services
 import cats.implicits._
 import common.errors.ClaimIdFormatError
 import shared.controllers.RequestContext
+import shared.models.domain.TaxYear
 import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
 import shared.services.{BaseService, ServiceOutcome}
-import v4.connectors.DeleteLossClaimConnector
+import v4.connectors.{DeleteLossClaimConnector, RetrieveLossClaimConnector}
 import v4.models.request.deleteLossClaim.DeleteLossClaimRequestData
+import v4.models.request.retrieveLossClaim.RetrieveLossClaimRequestData
+import v4.models.response.retrieveLossClaim.RetrieveLossClaimResponse
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class DeleteLossClaimService @Inject() (connector: DeleteLossClaimConnector) extends BaseService {
+class DeleteLossClaimService @Inject() (retrieveConnector: RetrieveLossClaimConnector, deleteConnector: DeleteLossClaimConnector)
+    extends BaseService {
 
-  def deleteLossClaim(request: DeleteLossClaimRequestData)(implicit ctx: RequestContext, ec: ExecutionContext): Future[ServiceOutcome[Unit]] =
-    connector
-      .deleteLossClaim(request)
-      .map(_.leftMap(mapDownstreamErrors(errorMap)))
+  def deleteLossClaim(request: DeleteLossClaimRequestData)(implicit ctx: RequestContext, ec: ExecutionContext): Future[ServiceOutcome[Unit]] = {
+    val retrieveRequest: RetrieveLossClaimRequestData = RetrieveLossClaimRequestData(request.nino, request.claimId)
+
+    for {
+      retrieveResult <- retrieveConnector.retrieveLossClaim(retrieveRequest)
+      deleteResult <- retrieveResult match {
+        case Right(ResponseWrapper(_, response: RetrieveLossClaimResponse)) =>
+          val taxYear: TaxYear = TaxYear.fromMtd(response.taxYearClaimedFor)
+          deleteConnector.deleteLossClaim(request, taxYear).map(_.leftMap(mapDownstreamErrors(errorMap)))
+
+        case Left(error) => Future.successful(Left(mapDownstreamErrors(errorMap)(error)))
+      }
+    } yield deleteResult
+  }
 
   private val errorMap: Map[String, MtdError] = Map(
     "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,

--- a/app/v5/bfLosses/amend/AmendBFLossConnector.scala
+++ b/app/v5/bfLosses/amend/AmendBFLossConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v5.bfLosses.amend.model.request.AmendBFLossRequestData
 import v5.bfLosses.amend.model.response.AmendBFLossResponse
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.reads
+import shared.models.domain.TaxYear.currentTaxYear
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +38,7 @@ class AmendBFLossConnector @Inject() (val http: HttpClient, val appConfig: Share
 
     import request._
     import schema._
-    val downstreamUri: DownstreamUri[DownstreamResp] = IfsUri(s"income-tax/brought-forward-losses/$nino/$lossId")
+    val downstreamUri: DownstreamUri[DownstreamResp] = IfsUri(s"income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId")
     put(amendBroughtForwardLoss, downstreamUri)
 
   }

--- a/app/v5/bfLosses/create/CreateBFLossConnector.scala
+++ b/app/v5/bfLosses/create/CreateBFLossConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import shared.config.SharedAppConfig
 import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser.reads
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
+import shared.models.domain.TaxYear.currentTaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v5.bfLosses.create.model.request.CreateBFLossRequestData
 import v5.bfLosses.create.model.response.CreateBFLossResponse
@@ -38,7 +39,7 @@ class CreateBFLossConnector @Inject() (val http: HttpClient, val appConfig: Shar
     import request._
     import schema._
 
-    val downstreamUri: DownstreamUri[DownstreamResp] = IfsUri(s"income-tax/brought-forward-losses/$nino")
+    val downstreamUri: DownstreamUri[DownstreamResp] = IfsUri(s"income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}")
 
     post(broughtForwardLoss, downstreamUri)
   }

--- a/app/v5/bfLosses/delete/DeleteBFLossConnector.scala
+++ b/app/v5/bfLosses/delete/DeleteBFLossConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package v5.bfLosses.delete
 import shared.connectors.DownstreamUri.{DesUri, HipUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
-import shared.config.{SharedAppConfig, ConfigFeatureSwitches}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.models.domain.TaxYear.currentTaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v5.bfLosses.delete.model.request.DeleteBFLossRequestData
 
@@ -34,7 +35,7 @@ class DeleteBFLossConnector @Inject() (val http: HttpClient, val appConfig: Shar
 
     import request._
     val downstreamUri = if (ConfigFeatureSwitches().isEnabled("des_hip_migration_1504")) {
-      HipUri[Unit](s"itsa/income-tax/v1/brought-forward-losses/$nino/$lossId")
+      HipUri[Unit](s"itsa/income-tax/v1/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId")
     } else {
       DesUri[Unit](s"income-tax/brought-forward-losses/$nino/$lossId")
     }

--- a/app/v5/lossClaims/amendType/AmendLossClaimTypeConnector.scala
+++ b/app/v5/lossClaims/amendType/AmendLossClaimTypeConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import shared.connectors.DownstreamUri.IfsUri
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
 import shared.config.SharedAppConfig
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v5.lossClaims.amendType.model.request.AmendLossClaimTypeRequestData
 import v5.lossClaims.amendType.model.response.AmendLossClaimTypeResponse
@@ -30,14 +31,15 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class AmendLossClaimTypeConnector @Inject() (val http: HttpClient, val appConfig: SharedAppConfig) extends BaseDownstreamConnector {
 
-  def amendLossClaimType(request: AmendLossClaimTypeRequestData)(implicit
+  def amendLossClaimType(request: AmendLossClaimTypeRequestData, taxYear: TaxYear)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext,
-      correlationId: String): Future[DownstreamOutcome[AmendLossClaimTypeResponse]] = {
+      correlationId: String
+  ): Future[DownstreamOutcome[AmendLossClaimTypeResponse]] = {
 
     import request._
     import schema._
-    val downstreamUri: DownstreamUri[DownstreamResp] = IfsUri(s"income-tax/claims-for-relief/$nino/$claimId")
+    val downstreamUri: DownstreamUri[DownstreamResp] = IfsUri(s"income-tax/claims-for-relief/$nino/${taxYear.asTysDownstream}/$claimId")
 
     put(body, downstreamUri)
   }

--- a/app/v5/lossClaims/delete/DeleteLossClaimConnector.scala
+++ b/app/v5/lossClaims/delete/DeleteLossClaimConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package v5.lossClaims.delete
 import shared.connectors.DownstreamUri.{DesUri, HipUri}
 import shared.connectors.httpparsers.StandardDownstreamHttpParser._
 import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
-import shared.config.{SharedAppConfig, ConfigFeatureSwitches}
+import shared.config.{ConfigFeatureSwitches, SharedAppConfig}
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import v5.lossClaims.delete.model.request.DeleteLossClaimRequestData
 
@@ -29,15 +30,16 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class DeleteLossClaimConnector @Inject() (val http: HttpClient, val appConfig: SharedAppConfig) extends BaseDownstreamConnector {
 
-  def deleteLossClaim(request: DeleteLossClaimRequestData)(implicit
+  def deleteLossClaim(request: DeleteLossClaimRequestData, taxYear: TaxYear)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext,
-      correlationId: String): Future[DownstreamOutcome[Unit]] = {
+      correlationId: String
+  ): Future[DownstreamOutcome[Unit]] = {
 
     import request._
 
     val downstreamUri = if (ConfigFeatureSwitches().isEnabled("des_hip_migration_1509")) {
-      HipUri[Unit](s"itsa/income-tax/v1/claims-for-relief/$nino/$claimId")
+      HipUri[Unit](s"itsa/income-tax/v1/claims-for-relief/$nino/${taxYear.asTysDownstream}/$claimId")
     } else {
       DesUri[Unit](s"income-tax/claims-for-relief/$nino/$claimId")
     }

--- a/it/v4/endpoints/bfLoss/amend/AmendBFLossControllerISpec.scala
+++ b/it/v4/endpoints/bfLoss/amend/AmendBFLossControllerISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,10 @@ package v4.endpoints.bfLoss.amend
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import common.errors.{LossIdFormatError, RuleLossAmountNotChanged}
-import play.api.http.HeaderNames.ACCEPT
-import play.api.http.Status
-import play.api.http.Status._
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
-import play.api.test.Helpers.AUTHORIZATION
+import play.api.test.Helpers._
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.errors._
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
@@ -33,40 +31,42 @@ class AmendBFLossControllerISpec extends IntegrationBaseSpec {
 
   val lossAmount = 2345.67
 
-  val downstreamResponseJson: JsValue = Json.parse(s"""
-       |{
-       |    "incomeSourceId": "XBIS12345678910",
-       |    "lossType": "INCOME",
-       |    "broughtForwardLossAmount": $lossAmount,
-       |    "taxYear": "2022",
-       |    "lossId": "AAZZ1234567890A",
-       |    "submissionDate": "2022-07-13T12:13:48.763Z"
-       |}
-      """.stripMargin)
+  val downstreamResponseJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceId": "XBIS12345678910",
+      |  "lossType": "INCOME",
+      |  "broughtForwardLossAmount": $lossAmount,
+      |  "taxYear": "2022",
+      |  "lossId": "AAZZ1234567890A",
+      |  "submissionDate": "2022-07-13T12:13:48.763Z"
+      |}
+    """.stripMargin
+  )
 
   val requestJson: JsValue = Json.parse(
     s"""
-       |{
-       |    "lossAmount": $lossAmount
-       |}
-      """.stripMargin
+      |{
+      |  "lossAmount": $lossAmount
+      |}
+    """.stripMargin
   )
 
   val invalidRequestJson: JsValue = Json.parse(
-    s"""
-       |{
-       |    "lossAmount": 23.2714
-       |}
-      """.stripMargin
+    """
+      |{
+      |  "lossAmount": 23.2714
+      |}
+    """.stripMargin
   )
 
   def errorBody(code: String): String =
     s"""
-       |      {
-       |        "code": "$code",
-       |        "reason": "downstream message"
-       |      }
-      """.stripMargin
+      |{
+      |  "code": "$code",
+      |  "reason": "downstream message"
+      |}
+    """.stripMargin
 
   object Hateoas extends V4HateoasLinks
 
@@ -75,35 +75,37 @@ class AmendBFLossControllerISpec extends IntegrationBaseSpec {
     val nino   = "AA123456A"
     val lossId = "AAZZ1234567890a"
 
-    val responseJson: JsValue = Json.parse(s"""
-         |{
-         |    "businessId": "XBIS12345678910",
-         |    "typeOfLoss": "self-employment",
-         |    "lossAmount": 2345.67,
-         |    "taxYearBroughtForwardFrom": "2021-22",
-         |    "lastModified": "2022-07-13T12:13:48.763Z",
-         |    "links": [
-         |      {
-         |        "href": "/individuals/losses/AA123456A/brought-forward-losses/AAZZ1234567890a",
-         |        "rel": "self",
-         |        "method": "GET"
-         |      },
-         |      {
-         |        "href": "/individuals/losses/AA123456A/brought-forward-losses/AAZZ1234567890a/change-loss-amount",
-         |        "rel": "amend-brought-forward-loss",
-         |        "method": "POST"
-         |      },
-         |      {
-         |        "href": "/individuals/losses/AA123456A/brought-forward-losses/AAZZ1234567890a",
-         |        "rel": "delete-brought-forward-loss",
-         |        "method": "DELETE"
-         |      }
-         |     ]
-         |}
-      """.stripMargin)
+    val responseJson: JsValue = Json.parse(
+      """
+        |{
+        |  "businessId": "XBIS12345678910",
+        |  "typeOfLoss": "self-employment",
+        |  "lossAmount": 2345.67,
+        |  "taxYearBroughtForwardFrom": "2021-22",
+        |  "lastModified": "2022-07-13T12:13:48.763Z",
+        |  "links": [
+        |    {
+        |      "href": "/individuals/losses/AA123456A/brought-forward-losses/AAZZ1234567890a",
+        |      "rel": "self",
+        |      "method": "GET"
+        |    },
+        |    {
+        |      "href": "/individuals/losses/AA123456A/brought-forward-losses/AAZZ1234567890a/change-loss-amount",
+        |      "rel": "amend-brought-forward-loss",
+        |      "method": "POST"
+        |    },
+        |    {
+        |      "href": "/individuals/losses/AA123456A/brought-forward-losses/AAZZ1234567890a",
+        |      "rel": "delete-brought-forward-loss",
+        |      "method": "DELETE"
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    )
 
-    def url: String    = s"/$nino/brought-forward-losses/$lossId/change-loss-amount"
-    def ifsUrl: String = s"/income-tax/brought-forward-losses/$nino/$lossId"
+    private def url: String   = s"/$nino/brought-forward-losses/$lossId/change-loss-amount"
+    def downstreamUrl: String = s"/income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId"
 
     def setupStubs(): StubMapping
 
@@ -127,11 +129,11 @@ class AmendBFLossControllerISpec extends IntegrationBaseSpec {
           AuditStub.audit()
           AuthStub.authorised()
           MtdIdLookupStub.ninoFound(nino)
-          DownstreamStub.onSuccess(DownstreamStub.PUT, ifsUrl, Status.OK, downstreamResponseJson)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, OK, downstreamResponseJson)
         }
 
         val response: WSResponse = await(request().post(requestJson))
-        response.status shouldBe Status.OK
+        response.status shouldBe OK
         response.json shouldBe responseJson
         response.header("X-CorrelationId").nonEmpty shouldBe true
         response.header("Content-Type") shouldBe Some("application/json")
@@ -173,14 +175,14 @@ class AmendBFLossControllerISpec extends IntegrationBaseSpec {
       }
 
       "downstream service error" when {
-        def serviceErrorTest(ifsStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"downstream returns an $downstreamCode error and status $ifsStatus" in new Test {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new Test {
 
             override def setupStubs(): StubMapping = {
               AuditStub.audit()
               AuthStub.authorised()
               MtdIdLookupStub.ninoFound(nino)
-              DownstreamStub.onError(DownstreamStub.PUT, ifsUrl, ifsStatus, errorBody(downstreamCode))
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUrl, downstreamStatus, errorBody(downstreamCode))
             }
 
             val response: WSResponse = await(request().post(requestJson))

--- a/it/v4/endpoints/bfLoss/delete/DeleteBFLossControllerISpec.scala
+++ b/it/v4/endpoints/bfLoss/delete/DeleteBFLossControllerISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,10 @@ package v4.endpoints.bfLoss.delete
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import common.errors.{LossIdFormatError, RuleDeleteAfterFinalDeclarationError}
-import play.api.http.HeaderNames.ACCEPT
-import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
-import play.api.test.Helpers.AUTHORIZATION
+import play.api.test.Helpers._
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.errors._
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
@@ -34,15 +33,15 @@ class DeleteBFLossControllerISpec extends IntegrationBaseSpec {
     val nino   = "AA123456A"
     val lossId = "AAZZ1234567890a"
 
-    def uri: String    = s"/$nino/brought-forward-losses/$lossId"
-    def hipUrl: String = s"/itsa/income-tax/v1/brought-forward-losses/$nino/$lossId"
+    private def uri: String   = s"/$nino/brought-forward-losses/$lossId"
+    def downstreamUrl: String = s"/itsa/income-tax/v1/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId"
 
     def errorBody(code: String): String =
       s"""
-         |      {
-         |        "code": "$code",
-         |        "reason": "downstream message"
-         |      }
+        |{
+        |  "code": "$code",
+        |  "reason": "downstream message"
+        |}
       """.stripMargin
 
     def setupStubs(): StubMapping
@@ -68,7 +67,7 @@ class DeleteBFLossControllerISpec extends IntegrationBaseSpec {
           AuditStub.audit()
           AuthStub.authorised()
           MtdIdLookupStub.ninoFound(nino)
-          DownstreamStub.onSuccess(DownstreamStub.DELETE, hipUrl, NO_CONTENT, JsObject.empty)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, downstreamUrl, NO_CONTENT, JsObject.empty)
         }
 
         val response: WSResponse = await(request().delete())
@@ -85,7 +84,7 @@ class DeleteBFLossControllerISpec extends IntegrationBaseSpec {
             AuditStub.audit()
             AuthStub.authorised()
             MtdIdLookupStub.ninoFound(nino)
-            DownstreamStub.onError(DownstreamStub.DELETE, hipUrl, desStatus, errorBody(desCode))
+            DownstreamStub.onError(DownstreamStub.DELETE, downstreamUrl, desStatus, errorBody(desCode))
           }
 
           val response: WSResponse = await(request().delete())

--- a/it/v4/endpoints/lossClaim/amendType/AmendLossClaimTypeISpec.scala
+++ b/it/v4/endpoints/lossClaim/amendType/AmendLossClaimTypeISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,77 +18,82 @@ package v4.endpoints.lossClaim.amendType
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import common.errors.{ClaimIdFormatError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid, TypeOfClaimFormatError}
-import play.api.http.HeaderNames.ACCEPT
-import play.api.http.Status._
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
-import play.api.test.Helpers.AUTHORIZATION
+import play.api.test.Helpers._
 import shared.models.errors._
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
 
 class AmendLossClaimTypeISpec extends IntegrationBaseSpec {
 
-  val downstreamResponseJson: JsValue = Json.parse(s"""
-       |{
-       |  "incomeSourceId": "XKIS00000000988",
-       |  "reliefClaimed": "CF",
-       |  "taxYearClaimedFor": "2020",
-       |  "claimId": "notUsed",
-       |  "sequence": 1,
-       |  "submissionDate": "2018-07-13T12:13:48.763Z"
-       |}
-      """.stripMargin)
+  val downstreamResponseJson: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceId": "XKIS00000000988",
+      |  "reliefClaimed": "CF",
+      |  "taxYearClaimedFor": "2020",
+      |  "claimId": "notUsed",
+      |  "sequence": 1,
+      |  "submissionDate": "2018-07-13T12:13:48.763Z"
+      |}
+    """.stripMargin
+  )
 
-  val requestJson: JsValue = Json.parse(s"""
-       |{
-       |    "typeOfClaim": "carry-forward"
-       |}
-      """.stripMargin)
+  val requestJson: JsValue = Json.parse(
+    """
+      |{
+      |  "typeOfClaim": "carry-forward"
+      |}
+    """.stripMargin
+  )
 
   private trait Test {
 
     val nino    = "AA123456A"
     val claimId = "AAZZ1234567890a"
 
-    val responseJson: JsValue = Json.parse(s"""
-         |{
-         |  "businessId": "XKIS00000000988",
-         |  "typeOfLoss": "self-employment",
-         |  "typeOfClaim": "carry-forward",
-         |  "taxYearClaimedFor": "2019-20",
-         |  "lastModified":"2018-07-13T12:13:48.763Z",
-         |  "sequence": 1,
-         |  "links": [
-         |    {
-         |      "href": "/individuals/losses/$nino/loss-claims/$claimId",
-         |      "method": "GET",
-         |      "rel": "self"
-         |    },
-         |    {
-         |      "href": "/individuals/losses/$nino/loss-claims/$claimId",
-         |      "method": "DELETE",
-         |      "rel": "delete-loss-claim"
-         |    },
-         |
-         |    {
-         |      "href": "/individuals/losses/$nino/loss-claims/$claimId/change-type-of-claim",
-         |      "method": "POST",
-         |      "rel": "amend-loss-claim"
-         |    }
-         |  ]
-         |}
-      """.stripMargin)
+    val responseJson: JsValue = Json.parse(
+      s"""
+        |{
+        |  "businessId": "XKIS00000000988",
+        |  "typeOfLoss": "self-employment",
+        |  "typeOfClaim": "carry-forward",
+        |  "taxYearClaimedFor": "2019-20",
+        |  "lastModified":"2018-07-13T12:13:48.763Z",
+        |  "sequence": 1,
+        |  "links": [
+        |    {
+        |      "href": "/individuals/losses/$nino/loss-claims/$claimId",
+        |      "method": "GET",
+        |      "rel": "self"
+        |    },
+        |    {
+        |      "href": "/individuals/losses/$nino/loss-claims/$claimId",
+        |      "method": "DELETE",
+        |      "rel": "delete-loss-claim"
+        |    },
+        |
+        |    {
+        |      "href": "/individuals/losses/$nino/loss-claims/$claimId/change-type-of-claim",
+        |      "method": "POST",
+        |      "rel": "amend-loss-claim"
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    )
 
-    def uri: String    = s"/$nino/loss-claims/$claimId/change-type-of-claim"
-    def ifsUrl: String = s"/income-tax/claims-for-relief/$nino/$claimId"
+    private def uri: String           = s"/$nino/loss-claims/$claimId/change-type-of-claim"
+    def amendDownstreamUrl: String    = s"/income-tax/claims-for-relief/$nino/19-20/$claimId"
+    def retrieveDownstreamUrl: String = s"/income-tax/claims-for-relief/$nino/$claimId"
 
     def errorBody(code: String): String =
       s"""
-         |      {
-         |        "code": "$code",
-         |        "reason": "downstream message"
-         |      }
+        |{
+        |  "code": "$code",
+        |  "reason": "downstream message"
+        |}
       """.stripMargin
 
     def setupStubs(): StubMapping
@@ -114,7 +119,8 @@ class AmendLossClaimTypeISpec extends IntegrationBaseSpec {
           AuditStub.audit()
           AuthStub.authorised()
           MtdIdLookupStub.ninoFound(nino)
-          DownstreamStub.onSuccess(DownstreamStub.PUT, ifsUrl, OK, downstreamResponseJson)
+          DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, downstreamResponseJson)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, amendDownstreamUrl, OK, downstreamResponseJson)
         }
 
         val response: WSResponse = await(request().post(requestJson))
@@ -126,14 +132,14 @@ class AmendLossClaimTypeISpec extends IntegrationBaseSpec {
     }
 
     "handle errors according to spec" when {
-      def serviceErrorTest(ifsStatus: Int, ifsCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-        s"downstream returns an $ifsCode error" in new Test {
+      def serviceRetrieveErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the retrieve connector call" in new Test {
 
           override def setupStubs(): StubMapping = {
             AuditStub.audit()
             AuthStub.authorised()
             MtdIdLookupStub.ninoFound(nino)
-            DownstreamStub.onError(DownstreamStub.PUT, ifsUrl, ifsStatus, errorBody(ifsCode))
+            DownstreamStub.onError(DownstreamStub.GET, retrieveDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
           }
 
           val response: WSResponse = await(request().post(requestJson))
@@ -142,17 +148,41 @@ class AmendLossClaimTypeISpec extends IntegrationBaseSpec {
           response.header("X-CorrelationId").nonEmpty shouldBe true
           response.header("Content-Type") shouldBe Some("application/json")
         }
-      }
 
-      serviceErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
-      serviceErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
-      serviceErrorTest(BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(UNPROCESSABLE_ENTITY, "INVALID_CLAIM_TYPE", BAD_REQUEST, RuleTypeOfClaimInvalid)
-      serviceErrorTest(CONFLICT, "CONFLICT", BAD_REQUEST, RuleClaimTypeNotChanged)
-      serviceErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
-      serviceErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+      def serviceAmendErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the amend connector call" in new Test {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+            DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, downstreamResponseJson)
+            DownstreamStub.onError(DownstreamStub.PUT, amendDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
+          }
+
+          val response: WSResponse = await(request().post(requestJson))
+          response.json shouldBe Json.toJson(expectedBody)
+          response.status shouldBe expectedStatus
+          response.header("X-CorrelationId").nonEmpty shouldBe true
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceRetrieveErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError)
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
+      serviceAmendErrorTest(UNPROCESSABLE_ENTITY, "INVALID_CLAIM_TYPE", BAD_REQUEST, RuleTypeOfClaimInvalid)
+      serviceAmendErrorTest(CONFLICT, "CONFLICT", BAD_REQUEST, RuleClaimTypeNotChanged)
+      serviceAmendErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceAmendErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceAmendErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
     }
 
     "handle validation errors according to spec" when {

--- a/it/v4/endpoints/lossClaim/delete/DeleteLossClaimISpec.scala
+++ b/it/v4/endpoints/lossClaim/delete/DeleteLossClaimISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,43 @@ package v4.endpoints.lossClaim.delete
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import common.errors.ClaimIdFormatError
-import play.api.http.HeaderNames.ACCEPT
-import play.api.http.Status
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
-import play.api.test.Helpers.AUTHORIZATION
+import play.api.test.Helpers._
 import shared.models.errors._
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
 
 class DeleteLossClaimISpec extends IntegrationBaseSpec {
 
+  val retrieveDownstreamResponseJson: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceId": "XKIS00000000988",
+      |  "reliefClaimed": "CF",
+      |  "taxYearClaimedFor": "2020",
+      |  "claimId": "notUsed",
+      |  "sequence": 1,
+      |  "submissionDate": "2018-07-13T12:13:48.763Z"
+      |}
+    """.stripMargin
+  )
+
   private trait Test {
 
     val nino    = "AA123456A"
     val claimId = "AAZZ1234567890a"
 
-    def uri: String    = s"/$nino/loss-claims/$claimId"
-    def hipUrl: String = s"/itsa/income-tax/v1/claims-for-relief/$nino/$claimId"
+    private def uri: String           = s"/$nino/loss-claims/$claimId"
+    def deleteDownstreamUrl: String   = s"/itsa/income-tax/v1/claims-for-relief/$nino/19-20/$claimId"
+    def retrieveDownstreamUrl: String = s"/income-tax/claims-for-relief/$nino/$claimId"
 
     def errorBody(code: String): String =
       s"""
-         |      {
-         |        "code": "$code",
-         |        "reason": "downstream message"
-         |      }
+        |{
+        |  "code": "$code",
+        |  "reason": "downstream message"
+        |}
       """.stripMargin
 
     def setupStubs(): StubMapping
@@ -68,24 +80,25 @@ class DeleteLossClaimISpec extends IntegrationBaseSpec {
           AuditStub.audit()
           AuthStub.authorised()
           MtdIdLookupStub.ninoFound(nino)
-          DownstreamStub.onSuccess(DownstreamStub.DELETE, hipUrl, Status.NO_CONTENT, JsObject.empty)
+          DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, retrieveDownstreamResponseJson)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, deleteDownstreamUrl, NO_CONTENT, JsObject.empty)
         }
 
         val response: WSResponse = await(request().delete())
-        response.status shouldBe Status.NO_CONTENT
+        response.status shouldBe NO_CONTENT
         response.header("X-CorrelationId").nonEmpty shouldBe true
       }
     }
 
     "handle errors according to spec" when {
-      def serviceErrorTest(desStatus: Int, desCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-        s"downstream returns an $desCode error" in new Test {
+      def serviceRetrieveErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the retrieve connector call" in new Test {
 
           override def setupStubs(): StubMapping = {
             AuditStub.audit()
             AuthStub.authorised()
             MtdIdLookupStub.ninoFound(nino)
-            DownstreamStub.onError(DownstreamStub.DELETE, hipUrl, desStatus, errorBody(desCode))
+            DownstreamStub.onError(DownstreamStub.GET, retrieveDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
           }
 
           val response: WSResponse = await(request().delete())
@@ -94,14 +107,38 @@ class DeleteLossClaimISpec extends IntegrationBaseSpec {
           response.header("X-CorrelationId").nonEmpty shouldBe true
           response.header("Content-Type") shouldBe Some("application/json")
         }
-      }
 
-      serviceErrorTest(Status.BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", Status.BAD_REQUEST, NinoFormatError)
-      serviceErrorTest(Status.BAD_REQUEST, "INVALID_CLAIM_ID", Status.BAD_REQUEST, ClaimIdFormatError)
-      serviceErrorTest(Status.BAD_REQUEST, "UNEXPECTED_DES_ERROR_CODE", Status.INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(Status.NOT_FOUND, "NOT_FOUND", Status.NOT_FOUND, NotFoundError)
-      serviceErrorTest(Status.INTERNAL_SERVER_ERROR, "SERVER_ERROR", Status.INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(Status.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", Status.INTERNAL_SERVER_ERROR, InternalError)
+      def serviceDeleteErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the delete connector call" in new Test {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+            DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, retrieveDownstreamResponseJson)
+            DownstreamStub.onError(DownstreamStub.DELETE, deleteDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
+          }
+
+          val response: WSResponse = await(request().delete())
+          response.status shouldBe expectedStatus
+          response.json shouldBe Json.toJson(expectedBody)
+          response.header("X-CorrelationId").nonEmpty shouldBe true
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceRetrieveErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+
+      serviceDeleteErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceDeleteErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceDeleteErrorTest(BAD_REQUEST, "UNEXPECTED_DOWNSTREAM_ERROR_CODE", INTERNAL_SERVER_ERROR, InternalError)
+      serviceDeleteErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceDeleteErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceDeleteErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
     }
 
     "handle validation errors according to spec" when {
@@ -123,8 +160,8 @@ class DeleteLossClaimISpec extends IntegrationBaseSpec {
         }
       }
 
-      validationErrorTest("BADNINO", "AAZZ1234567890a", Status.BAD_REQUEST, NinoFormatError)
-      validationErrorTest("AA123456A", "BADCLAIMID", Status.BAD_REQUEST, ClaimIdFormatError)
+      validationErrorTest("BADNINO", "AAZZ1234567890a", BAD_REQUEST, NinoFormatError)
+      validationErrorTest("AA123456A", "BADCLAIMID", BAD_REQUEST, ClaimIdFormatError)
     }
 
   }

--- a/it/v5/lossClaim/amendType/def1/Def1_AmendLossClaimTypeISpec.scala
+++ b/it/v5/lossClaim/amendType/def1/Def1_AmendLossClaimTypeISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,59 +18,64 @@ package v5.lossClaim.amendType.def1
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import common.errors._
-import play.api.http.HeaderNames.ACCEPT
-import play.api.http.Status._
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
-import play.api.test.Helpers.AUTHORIZATION
+import play.api.test.Helpers._
 import shared.models.errors._
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import shared.support.IntegrationBaseSpec
 
 class Def1_AmendLossClaimTypeISpec extends IntegrationBaseSpec {
 
-  val downstreamResponseJson: JsValue = Json.parse(s"""
-       |{
-       |  "incomeSourceId": "XKIS00000000988",
-       |  "reliefClaimed": "CF",
-       |  "taxYearClaimedFor": "2020",
-       |  "claimId": "notUsed",
-       |  "sequence": 1,
-       |  "submissionDate": "2018-07-13T12:13:48.763Z"
-       |}
-      """.stripMargin)
+  val downstreamResponseJson: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceId": "XKIS00000000988",
+      |  "reliefClaimed": "CF",
+      |  "taxYearClaimedFor": "2020",
+      |  "claimId": "notUsed",
+      |  "sequence": 1,
+      |  "submissionDate": "2018-07-13T12:13:48.763Z"
+      |}
+    """.stripMargin
+  )
 
-  val requestJson: JsValue = Json.parse(s"""
-       |{
-       |    "typeOfClaim": "carry-forward"
-       |}
-      """.stripMargin)
+  val requestJson: JsValue = Json.parse(
+    """
+      |{
+      |  "typeOfClaim": "carry-forward"
+      |}
+    """.stripMargin
+  )
 
   private trait Test {
 
     val nino    = "AA123456A"
     val claimId = "AAZZ1234567890a"
 
-    val responseJson: JsValue = Json.parse(s"""
-         |{
-         |  "businessId": "XKIS00000000988",
-         |  "typeOfLoss": "self-employment",
-         |  "typeOfClaim": "carry-forward",
-         |  "taxYearClaimedFor": "2019-20",
-         |  "lastModified":"2018-07-13T12:13:48.763Z",
-         |  "sequence": 1
-         |}
-      """.stripMargin)
+    val responseJson: JsValue = Json.parse(
+      """
+        |{
+        |  "businessId": "XKIS00000000988",
+        |  "typeOfLoss": "self-employment",
+        |  "typeOfClaim": "carry-forward",
+        |  "taxYearClaimedFor": "2019-20",
+        |  "lastModified":"2018-07-13T12:13:48.763Z",
+        |  "sequence": 1
+        |}
+      """.stripMargin
+    )
 
-    def uri: String    = s"/$nino/loss-claims/$claimId/change-type-of-claim"
-    def ifsUrl: String = s"/income-tax/claims-for-relief/$nino/$claimId"
+    private def uri: String           = s"/$nino/loss-claims/$claimId/change-type-of-claim"
+    def amendDownstreamUrl: String    = s"/income-tax/claims-for-relief/$nino/19-20/$claimId"
+    def retrieveDownstreamUrl: String = s"/income-tax/claims-for-relief/$nino/$claimId"
 
     def errorBody(code: String): String =
       s"""
-         |      {
-         |        "code": "$code",
-         |        "reason": "downstream message"
-         |      }
+        |{
+        |  "code": "$code",
+        |  "reason": "downstream message"
+        |}
       """.stripMargin
 
     def setupStubs(): StubMapping
@@ -96,7 +101,8 @@ class Def1_AmendLossClaimTypeISpec extends IntegrationBaseSpec {
           AuditStub.audit()
           AuthStub.authorised()
           MtdIdLookupStub.ninoFound(nino)
-          DownstreamStub.onSuccess(DownstreamStub.PUT, ifsUrl, OK, downstreamResponseJson)
+          DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, downstreamResponseJson)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, amendDownstreamUrl, OK, downstreamResponseJson)
         }
 
         val response: WSResponse = await(request().post(requestJson))
@@ -108,14 +114,14 @@ class Def1_AmendLossClaimTypeISpec extends IntegrationBaseSpec {
     }
 
     "handle errors according to spec" when {
-      def serviceErrorTest(ifsStatus: Int, ifsCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-        s"downstream returns an $ifsCode error" in new Test {
+      def serviceRetrieveErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the retrieve connector call" in new Test {
 
           override def setupStubs(): StubMapping = {
             AuditStub.audit()
             AuthStub.authorised()
             MtdIdLookupStub.ninoFound(nino)
-            DownstreamStub.onError(DownstreamStub.PUT, ifsUrl, ifsStatus, errorBody(ifsCode))
+            DownstreamStub.onError(DownstreamStub.GET, retrieveDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
           }
 
           val response: WSResponse = await(request().post(requestJson))
@@ -124,18 +130,42 @@ class Def1_AmendLossClaimTypeISpec extends IntegrationBaseSpec {
           response.header("X-CorrelationId").nonEmpty shouldBe true
           response.header("Content-Type") shouldBe Some("application/json")
         }
-      }
 
-      serviceErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
-      serviceErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
-      serviceErrorTest(BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(UNPROCESSABLE_ENTITY, "INVALID_CLAIM_TYPE", BAD_REQUEST, RuleTypeOfClaimInvalid)
-      serviceErrorTest(UNPROCESSABLE_ENTITY, "CSFHL_CLAIM_NOT_SUPPORTED", BAD_REQUEST, RuleCSFHLClaimNotSupportedError)
-      serviceErrorTest(CONFLICT, "CONFLICT", BAD_REQUEST, RuleClaimTypeNotChanged)
-      serviceErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
-      serviceErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+      def serviceAmendErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the amend connector call" in new Test {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+            DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, downstreamResponseJson)
+            DownstreamStub.onError(DownstreamStub.PUT, amendDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
+          }
+
+          val response: WSResponse = await(request().post(requestJson))
+          response.json shouldBe Json.toJson(expectedBody)
+          response.status shouldBe expectedStatus
+          response.header("X-CorrelationId").nonEmpty shouldBe true
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceRetrieveErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError)
+      serviceAmendErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
+      serviceAmendErrorTest(UNPROCESSABLE_ENTITY, "INVALID_CLAIM_TYPE", BAD_REQUEST, RuleTypeOfClaimInvalid)
+      serviceAmendErrorTest(UNPROCESSABLE_ENTITY, "CSFHL_CLAIM_NOT_SUPPORTED", BAD_REQUEST, RuleCSFHLClaimNotSupportedError)
+      serviceAmendErrorTest(CONFLICT, "CONFLICT", BAD_REQUEST, RuleClaimTypeNotChanged)
+      serviceAmendErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceAmendErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceAmendErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
     }
 
     "handle validation errors according to spec" when {

--- a/it/v5/lossClaim/delete/def1/Def1_DeleteLossClaimISpec.scala
+++ b/it/v5/lossClaim/delete/def1/Def1_DeleteLossClaimISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,30 +19,42 @@ package v5.lossClaim.delete.def1
 import shared.models.errors._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import common.errors.ClaimIdFormatError
-import play.api.http.HeaderNames.ACCEPT
-import play.api.http.Status
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
-import play.api.test.Helpers.AUTHORIZATION
+import play.api.test.Helpers._
 import shared.support.IntegrationBaseSpec
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 
 class Def1_DeleteLossClaimISpec extends IntegrationBaseSpec {
+
+  val retrieveDownstreamResponseJson: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceId": "XKIS00000000988",
+      |  "reliefClaimed": "CF",
+      |  "taxYearClaimedFor": "2020",
+      |  "claimId": "notUsed",
+      |  "sequence": 1,
+      |  "submissionDate": "2018-07-13T12:13:48.763Z"
+      |}
+    """.stripMargin
+  )
 
   private trait Test {
 
     val nino    = "AA123456A"
     val claimId = "AAZZ1234567890a"
 
-    def uri: String    = s"/$nino/loss-claims/$claimId"
-    def hipUrl: String = s"/itsa/income-tax/v1/claims-for-relief/$nino/$claimId"
+    private def uri: String           = s"/$nino/loss-claims/$claimId"
+    def deleteDownstreamUrl: String   = s"/itsa/income-tax/v1/claims-for-relief/$nino/19-20/$claimId"
+    def retrieveDownstreamUrl: String = s"/income-tax/claims-for-relief/$nino/$claimId"
 
     def errorBody(code: String): String =
       s"""
-         |      {
-         |        "code": "$code",
-         |        "reason": "downstream message"
-         |      }
+        |{
+        |  "code": "$code",
+        |  "reason": "downstream message"
+        |}
       """.stripMargin
 
     def setupStubs(): StubMapping
@@ -68,24 +80,25 @@ class Def1_DeleteLossClaimISpec extends IntegrationBaseSpec {
           AuditStub.audit()
           AuthStub.authorised()
           MtdIdLookupStub.ninoFound(nino)
-          DownstreamStub.onSuccess(DownstreamStub.DELETE, hipUrl, Status.NO_CONTENT, JsObject.empty)
+          DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, retrieveDownstreamResponseJson)
+          DownstreamStub.onSuccess(DownstreamStub.DELETE, deleteDownstreamUrl, NO_CONTENT, JsObject.empty)
         }
 
         val response: WSResponse = await(request().delete())
-        response.status shouldBe Status.NO_CONTENT
+        response.status shouldBe NO_CONTENT
         response.header("X-CorrelationId").nonEmpty shouldBe true
       }
     }
 
     "handle errors according to spec" when {
-      def serviceErrorTest(desStatus: Int, desCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-        s"downstream returns an $desCode error" in new Test {
+      def serviceRetrieveErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the retrieve connector call" in new Test {
 
           override def setupStubs(): StubMapping = {
             AuditStub.audit()
             AuthStub.authorised()
             MtdIdLookupStub.ninoFound(nino)
-            DownstreamStub.onError(DownstreamStub.DELETE, hipUrl, desStatus, errorBody(desCode))
+            DownstreamStub.onError(DownstreamStub.GET, retrieveDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
           }
 
           val response: WSResponse = await(request().delete())
@@ -94,14 +107,38 @@ class Def1_DeleteLossClaimISpec extends IntegrationBaseSpec {
           response.header("X-CorrelationId").nonEmpty shouldBe true
           response.header("Content-Type") shouldBe Some("application/json")
         }
-      }
 
-      serviceErrorTest(Status.BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", Status.BAD_REQUEST, NinoFormatError)
-      serviceErrorTest(Status.BAD_REQUEST, "INVALID_CLAIM_ID", Status.BAD_REQUEST, ClaimIdFormatError)
-      serviceErrorTest(Status.BAD_REQUEST, "UNEXPECTED_DES_ERROR_CODE", Status.INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(Status.NOT_FOUND, "NOT_FOUND", Status.NOT_FOUND, NotFoundError)
-      serviceErrorTest(Status.INTERNAL_SERVER_ERROR, "SERVER_ERROR", Status.INTERNAL_SERVER_ERROR, InternalError)
-      serviceErrorTest(Status.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", Status.INTERNAL_SERVER_ERROR, InternalError)
+      def serviceDeleteErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns a code $downstreamCode error from the delete connector call" in new Test {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+            DownstreamStub.onSuccess(DownstreamStub.GET, retrieveDownstreamUrl, OK, retrieveDownstreamResponseJson)
+            DownstreamStub.onError(DownstreamStub.DELETE, deleteDownstreamUrl, downstreamStatus, errorBody(downstreamCode))
+          }
+
+          val response: WSResponse = await(request().delete())
+          response.status shouldBe expectedStatus
+          response.json shouldBe Json.toJson(expectedBody)
+          response.header("X-CorrelationId").nonEmpty shouldBe true
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceRetrieveErrorTest(BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceRetrieveErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceRetrieveErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+
+      serviceDeleteErrorTest(BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError)
+      serviceDeleteErrorTest(BAD_REQUEST, "INVALID_CLAIM_ID", BAD_REQUEST, ClaimIdFormatError)
+      serviceDeleteErrorTest(BAD_REQUEST, "UNEXPECTED_DOWNSTREAM_ERROR_CODE", INTERNAL_SERVER_ERROR, InternalError)
+      serviceDeleteErrorTest(NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError)
+      serviceDeleteErrorTest(INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError)
+      serviceDeleteErrorTest(SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
     }
 
     "handle validation errors according to spec" when {
@@ -123,8 +160,8 @@ class Def1_DeleteLossClaimISpec extends IntegrationBaseSpec {
         }
       }
 
-      validationErrorTest("BADNINO", "AAZZ1234567890a", Status.BAD_REQUEST, NinoFormatError)
-      validationErrorTest("AA123456A", "BADCLAIMID", Status.BAD_REQUEST, ClaimIdFormatError)
+      validationErrorTest("BADNINO", "AAZZ1234567890a", BAD_REQUEST, NinoFormatError)
+      validationErrorTest("AA123456A", "BADCLAIMID", BAD_REQUEST, ClaimIdFormatError)
     }
 
   }

--- a/test/v4/connectors/AmendBFLossConnectorSpec.scala
+++ b/test/v4/connectors/AmendBFLossConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package v4.connectors
 
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.domain.{Nino, Timestamp}
 import shared.models.outcomes.ResponseWrapper
 import v4.models.domain.bfLoss.{LossId, TypeOfLoss}
@@ -41,7 +42,7 @@ class AmendBFLossConnectorSpec extends ConnectorSpec {
   }
 
   "amendBFLosses" should {
-    "return the expected response for a non-TYS request" when {
+    "return the expected response for a valid request" when {
       "downstream returns OK" in new IfsTest with Test {
         private val response = AmendBFLossResponse(
           businessId = "XKIS00000000988",
@@ -54,7 +55,7 @@ class AmendBFLossConnectorSpec extends ConnectorSpec {
         private val expected = Right(ResponseWrapper(correlationId, response))
 
         willPut(
-          url = s"$baseUrl/income-tax/brought-forward-losses/$nino/$lossId",
+          url = s"$baseUrl/income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId",
           body = requestBody
         ).returns(Future.successful(expected))
 

--- a/test/v4/connectors/AmendLossClaimTypeConnectorSpec.scala
+++ b/test/v4/connectors/AmendLossClaimTypeConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package v4.connectors
 
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
-import shared.models.domain.{Nino, Timestamp}
+import shared.models.domain.{Nino, TaxYear, Timestamp}
 import shared.models.outcomes.ResponseWrapper
 import uk.gov.hmrc.http.HeaderCarrier
 import v4.models.domain.lossClaim.{ClaimId, TypeOfClaim, TypeOfLoss}
@@ -28,8 +28,9 @@ import scala.concurrent.Future
 
 class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
 
-  val nino: String    = "AA123456A"
-  val claimId: String = "AAZZ1234567890ag"
+  val nino: String              = "AA123456A"
+  val claimId: String           = "AAZZ1234567890ag"
+  val taxYearClaimedFor: String = "2019-20"
 
   trait Test {
     _: ConnectorTest =>
@@ -44,7 +45,7 @@ class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
       businessId = "XKIS00000000988",
       typeOfLoss = TypeOfLoss.`self-employment`,
       typeOfClaim = TypeOfClaim.`carry-forward`,
-      taxYearClaimedFor = "2019-20",
+      taxYearClaimedFor = taxYearClaimedFor,
       sequence = Some(1),
       lastModified = Timestamp("2018-07-13T12:13:48.763Z")
     )
@@ -57,7 +58,7 @@ class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
       "return a successful response with the correct correlationId" in new IfsTest with Test {
         val expected: Right[Nothing, ResponseWrapper[AmendLossClaimTypeResponse]] = Right(ResponseWrapper(correlationId, response))
 
-        willPut(s"$baseUrl/income-tax/claims-for-relief/$nino/$claimId", amendLossClaimType).returning(Future.successful(expected))
+        willPut(s"$baseUrl/income-tax/claims-for-relief/$nino/19-20/$claimId", amendLossClaimType).returning(Future.successful(expected))
 
         val result: DownstreamOutcome[AmendLossClaimTypeResponse] = amendLossClaimTypeResult(connector)
         result shouldBe expected
@@ -71,7 +72,10 @@ class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
             nino = Nino(nino),
             claimId = ClaimId(claimId),
             amendLossClaimType
-          )))
+          ),
+          TaxYear.fromMtd(taxYearClaimedFor)
+        )
+      )
   }
 
 }

--- a/test/v4/connectors/CreateBFLossConnectorSpec.scala
+++ b/test/v4/connectors/CreateBFLossConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package v4.connectors
 
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
 import shared.models.domain.Nino
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.outcomes.ResponseWrapper
 import v4.models.domain.bfLoss.TypeOfLoss
 import v4.models.request.createBFLosses.{CreateBFLossRequestBody, CreateBFLossRequestData}
@@ -41,13 +42,13 @@ class CreateBFLossConnectorSpec extends ConnectorSpec {
   }
 
   "createBFLosses" should {
-    "return the expected response for a non-TYS request" when {
+    "return the expected response for a valid request" when {
       "downstream returns OK" in new IfsTest with Test {
         val response: CreateBFLossResponse                                  = CreateBFLossResponse(lossId)
         val expected: Right[Nothing, ResponseWrapper[CreateBFLossResponse]] = Right(ResponseWrapper(correlationId, response))
 
         willPost(
-          url = s"$baseUrl/income-tax/brought-forward-losses/$nino",
+          url = s"$baseUrl/income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}",
           body = requestBody
         ).returns(Future.successful(expected))
 

--- a/test/v4/connectors/DeleteBFLossConnectorSpec.scala
+++ b/test/v4/connectors/DeleteBFLossConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package v4.connectors
 import play.api.Configuration
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
 import shared.models.domain.Nino
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.outcomes.ResponseWrapper
 import v4.models.domain.bfLoss.LossId
 import v4.models.request.deleteBFLosses.DeleteBFLossRequestData
@@ -33,7 +34,7 @@ class DeleteBFLossConnectorSpec extends ConnectorSpec {
   val request: DeleteBFLossRequestData = DeleteBFLossRequestData(nino = Nino(nino), lossId = LossId(lossId))
 
   "deleteBFLosses" when {
-    "given a non-TYS request" when {
+    "given a valid request" when {
       "DES is not migrated to HIP" must {
         "return a success response" in new DesTest with Test {
           MockedSharedAppConfig.featureSwitchConfig returns Configuration("des_hip_migration_1504.enabled" -> false)
@@ -53,7 +54,7 @@ class DeleteBFLossConnectorSpec extends ConnectorSpec {
 
           val expected: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
-          willDelete(url = s"$baseUrl/itsa/income-tax/v1/brought-forward-losses/$nino/$lossId")
+          willDelete(url = s"$baseUrl/itsa/income-tax/v1/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId")
             .returning(Future.successful(expected))
 
           val result: DownstreamOutcome[Unit] = await(connector.deleteBFLoss(request))

--- a/test/v4/connectors/DeleteLossClaimConnectorSpec.scala
+++ b/test/v4/connectors/DeleteLossClaimConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package v4.connectors
 
 import play.api.Configuration
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
-import shared.models.domain.Nino
+import shared.models.domain.{Nino, TaxYear}
 import shared.models.outcomes.ResponseWrapper
 import v4.models.domain.lossClaim.ClaimId
 import v4.models.request.deleteLossClaim.DeleteLossClaimRequestData
@@ -27,8 +27,9 @@ import scala.concurrent.Future
 
 class DeleteLossClaimConnectorSpec extends ConnectorSpec {
 
-  private val nino    = Nino("AA123456A")
-  private val claimId = ClaimId("AAZZ1234567890ag")
+  private val nino              = Nino("AA123456A")
+  private val claimId           = ClaimId("AAZZ1234567890ag")
+  private val taxYearClaimedFor = TaxYear.fromMtd("2019-20")
 
   "delete LossClaim" when {
     "given a valid request" when {
@@ -41,7 +42,7 @@ class DeleteLossClaimConnectorSpec extends ConnectorSpec {
           willDelete(s"$baseUrl/income-tax/claims-for-relief/$nino/$claimId")
             .returning(Future.successful(expected))
 
-          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request))
+          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request, taxYearClaimedFor))
           result shouldBe expected
         }
       }
@@ -51,10 +52,10 @@ class DeleteLossClaimConnectorSpec extends ConnectorSpec {
           MockedSharedAppConfig.featureSwitchConfig returns Configuration("des_hip_migration_1509.enabled" -> true)
           val expected: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
-          willDelete(s"$baseUrl/itsa/income-tax/v1/claims-for-relief/$nino/$claimId")
+          willDelete(s"$baseUrl/itsa/income-tax/v1/claims-for-relief/$nino/19-20/$claimId")
             .returning(Future.successful(expected))
 
-          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request))
+          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request, taxYearClaimedFor))
           result shouldBe expected
         }
       }

--- a/test/v4/connectors/MockAmendLossClaimTypeConnector.scala
+++ b/test/v4/connectors/MockAmendLossClaimTypeConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package v4.connectors
 import shared.connectors.DownstreamOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.HeaderCarrier
 import v4.models.request.amendLossClaimType.AmendLossClaimTypeRequestData
 import v4.models.response.amendLossClaimType.AmendLossClaimTypeResponse
@@ -31,11 +32,11 @@ trait MockAmendLossClaimTypeConnector extends MockFactory {
 
   object MockAmendLossClaimTypeConnector {
 
-    def amendLossClaimType(request: AmendLossClaimTypeRequestData): CallHandler[Future[DownstreamOutcome[AmendLossClaimTypeResponse]]] = {
+    def amendLossClaimType(request: AmendLossClaimTypeRequestData,
+                           taxYear: TaxYear): CallHandler[Future[DownstreamOutcome[AmendLossClaimTypeResponse]]] =
       (mockAmendLossClaimTypeConnector
-        .amendLossClaimType(_: AmendLossClaimTypeRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
-        .expects(request, *, *, *)
-    }
+        .amendLossClaimType(_: AmendLossClaimTypeRequestData, _: TaxYear)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(request, taxYear, *, *, *)
 
   }
 

--- a/test/v4/connectors/MockDeleteLossClaimConnector.scala
+++ b/test/v4/connectors/MockDeleteLossClaimConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,21 @@ package v4.connectors
 import shared.connectors.DownstreamOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.HeaderCarrier
 import v4.models.request.deleteLossClaim.DeleteLossClaimRequestData
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait MockDeleteLossClaimConnector extends MockFactory {
-  val connector: DeleteLossClaimConnector = mock[DeleteLossClaimConnector]
+  val mockDeleteLossClaimConnector: DeleteLossClaimConnector = mock[DeleteLossClaimConnector]
 
   object MockDeleteLossClaimConnector {
 
-    def deleteLossClaim(deleteLossClaimRequest: DeleteLossClaimRequestData): CallHandler[Future[DownstreamOutcome[Unit]]] = {
-      (connector
-        .deleteLossClaim(_: DeleteLossClaimRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
-        .expects(deleteLossClaimRequest, *, *, *)
-    }
+    def deleteLossClaim(deleteLossClaimRequest: DeleteLossClaimRequestData, taxYear: TaxYear): CallHandler[Future[DownstreamOutcome[Unit]]] =
+      (mockDeleteLossClaimConnector
+        .deleteLossClaim(_: DeleteLossClaimRequestData, _: TaxYear)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(deleteLossClaimRequest, taxYear, *, *, *)
 
   }
 

--- a/test/v4/connectors/MockRetrieveLossClaimConnector.scala
+++ b/test/v4/connectors/MockRetrieveLossClaimConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,15 +26,15 @@ import v4.models.response.retrieveLossClaim.RetrieveLossClaimResponse
 import scala.concurrent.{ExecutionContext, Future}
 
 trait MockRetrieveLossClaimConnector extends MockFactory {
-  val connector: RetrieveLossClaimConnector = mock[RetrieveLossClaimConnector]
+  val mockRetrieveLossClaimConnector: RetrieveLossClaimConnector = mock[RetrieveLossClaimConnector]
 
   object MockRetrieveLossClaimConnector {
 
-    def retrieveLossClaim(request: RetrieveLossClaimRequestData): CallHandler[Future[DownstreamOutcome[RetrieveLossClaimResponse]]] = {
-      (connector
-        .retrieveLossClaim(_: RetrieveLossClaimRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
-        .expects(request, *, *, *)
-    }
+    def retrieveLossClaim(request: RetrieveLossClaimRequestData,
+                          isAmendRequest: Boolean): CallHandler[Future[DownstreamOutcome[RetrieveLossClaimResponse]]] =
+      (mockRetrieveLossClaimConnector
+        .retrieveLossClaim(_: RetrieveLossClaimRequestData, _: Boolean)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(request, isAmendRequest, *, *, *)
 
   }
 

--- a/test/v4/services/RetrieveLossClaimServiceSpec.scala
+++ b/test/v4/services/RetrieveLossClaimServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
   val claimId: String = "AAZZ1234567890a"
 
   trait Test extends MockRetrieveLossClaimConnector {
-    lazy val service = new RetrieveLossClaimService(connector)
+    lazy val service = new RetrieveLossClaimService(mockRetrieveLossClaimConnector)
   }
 
   lazy val request: RetrieveLossClaimRequestData = RetrieveLossClaimRequestData(Nino(nino), ClaimId(claimId))
@@ -54,7 +54,9 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
               Timestamp("2018-07-13T12:13:48.763Z")
             )
           )
-        MockRetrieveLossClaimConnector.retrieveLossClaim(request).returns(Future.successful(Right(downstreamResponse)))
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = request, isAmendRequest = false)
+          .returns(Future.successful(Right(downstreamResponse)))
 
         await(service.retrieveLossClaim(request)) shouldBe Right(downstreamResponse)
       }
@@ -64,7 +66,9 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
       "the connector returns an outbound error" in new Test {
         val someError: MtdError                                = MtdError("SOME_CODE", "some message", BAD_REQUEST)
         val downstreamResponse: ResponseWrapper[OutboundError] = ResponseWrapper(correlationId, OutboundError(someError))
-        MockRetrieveLossClaimConnector.retrieveLossClaim(request).returns(Future.successful(Left(downstreamResponse)))
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = request, isAmendRequest = false)
+          .returns(Future.successful(Left(downstreamResponse)))
 
         await(service.retrieveLossClaim(request)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
       }
@@ -75,7 +79,7 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
         s"a $downstreamErrorCode error is returned from the service" in new Test {
 
           MockRetrieveLossClaimConnector
-            .retrieveLossClaim(request)
+            .retrieveLossClaim(request = request, isAmendRequest = false)
             .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
 
           private val result = await(service.retrieveLossClaim(request))

--- a/test/v5/bfLosses/amend/AmendBFLossConnectorSpec.scala
+++ b/test/v5/bfLosses/amend/AmendBFLossConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package v5.bfLosses.amend
 
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.domain.{Nino, Timestamp}
 import shared.models.outcomes.ResponseWrapper
 import v5.bfLosses.amend.def1.model.request.{Def1_AmendBFLossRequestBody, Def1_AmendBFLossRequestData}
@@ -35,7 +36,7 @@ class AmendBFLossConnectorSpec extends ConnectorSpec {
   val request: Def1_AmendBFLossRequestData     = Def1_AmendBFLossRequestData(nino = Nino(nino), lossId = LossId(lossId), requestBody)
 
   "amendBFLosses" should {
-    "return the expected response for a non-TYS request" when {
+    "return the expected response for a valid request" when {
       "downstream returns OK" in new IfsTest with Test {
         val response: AmendBFLossResponse = Def1_AmendBFLossResponse(
           businessId = "XKIS00000000988",
@@ -47,7 +48,7 @@ class AmendBFLossConnectorSpec extends ConnectorSpec {
         val expected: Right[Nothing, ResponseWrapper[AmendBFLossResponse]] = Right(ResponseWrapper(correlationId, response))
 
         willPut(
-          url = s"$baseUrl/income-tax/brought-forward-losses/$nino/$lossId",
+          url = s"$baseUrl/income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId",
           body = requestBody
         ).returning(Future.successful(expected))
 

--- a/test/v5/bfLosses/create/CreateBFLossConnectorSpec.scala
+++ b/test/v5/bfLosses/create/CreateBFLossConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package v5.bfLosses.create
 
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
 import shared.models.domain.Nino
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.outcomes.ResponseWrapper
 import v5.bfLosses.common.domain.TypeOfLoss
 import v5.bfLosses.create.def1.model.request.{Def1_CreateBFLossRequestBody, Def1_CreateBFLossRequestData}
@@ -35,13 +36,13 @@ class CreateBFLossConnectorSpec extends ConnectorSpec {
   private val request     = Def1_CreateBFLossRequestData(nino = Nino(nino), requestBody)
 
   "createBFLosses" should {
-    "return the expected response for a non-TYS request" when {
+    "return the expected response for a valid request" when {
       "downstream returns OK" in new IfsTest with Test {
         val response: CreateBFLossResponse                                  = Def1_CreateBFLossResponse(lossId)
         val expected: Right[Nothing, ResponseWrapper[CreateBFLossResponse]] = Right(ResponseWrapper(correlationId, response))
 
         willPost(
-          url = s"$baseUrl/income-tax/brought-forward-losses/$nino",
+          url = s"$baseUrl/income-tax/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}",
           body = requestBody
         ).returning(Future.successful(expected))
 

--- a/test/v5/bfLosses/delete/DeleteBFLossConnectorSpec.scala
+++ b/test/v5/bfLosses/delete/DeleteBFLossConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package v5.bfLosses.delete
 import play.api.Configuration
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
 import shared.models.domain.Nino
+import shared.models.domain.TaxYear.currentTaxYear
 import shared.models.outcomes.ResponseWrapper
 import v5.bfLosses.common.domain.LossId
 import v5.bfLosses.delete.def1.model.request.Def1_DeleteBFLossRequestData
@@ -34,7 +35,7 @@ class DeleteBFLossConnectorSpec extends ConnectorSpec {
   val request: DeleteBFLossRequestData = Def1_DeleteBFLossRequestData(nino = Nino(nino), lossId = LossId(lossId))
 
   "deleteBFLosses" when {
-    "given a non-TYS request" when {
+    "given a valid request" when {
       "DES is not migrated to HIP" must {
         "return a success response" in new DesTest with Test {
           MockedSharedAppConfig.featureSwitchConfig returns Configuration("des_hip_migration_1504.enabled" -> false)
@@ -54,7 +55,7 @@ class DeleteBFLossConnectorSpec extends ConnectorSpec {
 
           val expected: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
-          willDelete(url = s"$baseUrl/itsa/income-tax/v1/brought-forward-losses/$nino/$lossId")
+          willDelete(url = s"$baseUrl/itsa/income-tax/v1/brought-forward-losses/$nino/${currentTaxYear.asTysDownstream}/$lossId")
             .returning(Future.successful(expected))
 
           val result: DownstreamOutcome[Unit] = await(connector.deleteBFLoss(request))

--- a/test/v5/lossClaims/amendType/AmendLossClaimTypeConnectorSpec.scala
+++ b/test/v5/lossClaims/amendType/AmendLossClaimTypeConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package v5.lossClaims.amendType
 
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
-import shared.models.domain.{Nino, Timestamp}
+import shared.models.domain.{Nino, TaxYear, Timestamp}
 import shared.models.outcomes.ResponseWrapper
 import v5.lossClaims.amendType.def1.model.request.{Def1_AmendLossClaimTypeRequestBody, Def1_AmendLossClaimTypeRequestData}
 import v5.lossClaims.amendType.def1.model.response.Def1_AmendLossClaimTypeResponse
@@ -28,8 +28,9 @@ import scala.concurrent.Future
 
 class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
 
-  val nino: String    = "AA123456A"
-  val claimId: String = "AAZZ1234567890ag"
+  val nino: String              = "AA123456A"
+  val claimId: String           = "AAZZ1234567890ag"
+  val taxYearClaimedFor: String = "2019-20"
 
   "amendLossClaimType" when {
 
@@ -37,7 +38,7 @@ class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
       businessId = "XKIS00000000988",
       typeOfLoss = TypeOfLoss.`self-employment`,
       typeOfClaim = TypeOfClaim.`carry-forward`,
-      taxYearClaimedFor = "2019-20",
+      taxYearClaimedFor = taxYearClaimedFor,
       sequence = Some(1),
       lastModified = Timestamp("2018-07-13T12:13:48.763Z")
     )
@@ -48,7 +49,7 @@ class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
       "return a successful response with the correct correlationId" in new IfsTest with Test {
         val expected: Right[Nothing, ResponseWrapper[AmendLossClaimTypeResponse]] = Right(ResponseWrapper(correlationId, response))
 
-        willPut(s"$baseUrl/income-tax/claims-for-relief/$nino/$claimId", amendLossClaimType)
+        willPut(s"$baseUrl/income-tax/claims-for-relief/$nino/19-20/$claimId", amendLossClaimType)
           .returning(Future.successful(expected))
 
         val result: DownstreamOutcome[AmendLossClaimTypeResponse] = amendLossClaimTypeResult(connector)
@@ -63,7 +64,10 @@ class AmendLossClaimTypeConnectorSpec extends ConnectorSpec {
             nino = Nino(nino),
             claimId = ClaimId(claimId),
             amendLossClaimType
-          )))
+          ),
+          TaxYear.fromMtd(taxYearClaimedFor)
+        )
+      )
   }
 
   trait Test { _: ConnectorTest =>

--- a/test/v5/lossClaims/amendType/AmendLossClaimTypeServiceSpec.scala
+++ b/test/v5/lossClaims/amendType/AmendLossClaimTypeServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package v5.lossClaims.amendType
 
 import common.errors.{ClaimIdFormatError, RuleCSFHLClaimNotSupportedError, RuleClaimTypeNotChanged, RuleTypeOfClaimInvalid}
-import shared.models.domain.{Nino, Timestamp}
+import shared.models.domain.{Nino, TaxYear, Timestamp}
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
 import shared.services.ServiceSpec
@@ -25,6 +25,10 @@ import v5.lossClaims.amendType.def1.model.request.{Def1_AmendLossClaimTypeReques
 import v5.lossClaims.amendType.def1.model.response.Def1_AmendLossClaimTypeResponse
 import v5.lossClaims.amendType.model.response.AmendLossClaimTypeResponse
 import v5.lossClaims.common.models.{ClaimId, TypeOfClaim, TypeOfLoss}
+import v5.lossClaims.retrieve.MockRetrieveLossClaimConnector
+import v5.lossClaims.retrieve.def1.model.request.Def1_RetrieveLossClaimRequestData
+import v5.lossClaims.retrieve.def1.model.response.Def1_RetrieveLossClaimResponse
+import v5.lossClaims.retrieve.model.request.RetrieveLossClaimRequestData
 
 import scala.concurrent.Future
 
@@ -35,7 +39,7 @@ class AmendLossClaimTypeServiceSpec extends ServiceSpec {
 
   val requestBody: Def1_AmendLossClaimTypeRequestBody = Def1_AmendLossClaimTypeRequestBody(TypeOfClaim.`carry-forward`)
 
-  val lossClaimResponse: AmendLossClaimTypeResponse =
+  val amendLossClaimResponse: AmendLossClaimTypeResponse =
     Def1_AmendLossClaimTypeResponse(
       "2019-20",
       TypeOfLoss.`self-employment`,
@@ -45,46 +49,107 @@ class AmendLossClaimTypeServiceSpec extends ServiceSpec {
       Timestamp("2018-07-13T12:13:48.763Z")
     )
 
-  trait Test extends MockAmendLossClaimTypeConnector {
-    lazy val service = new AmendLossClaimTypeService(mockAmendLossClaimTypeConnector)
-    val request      = Def1_AmendLossClaimTypeRequestData(Nino(nino), ClaimId(claimId), requestBody)
+  val retrieveLossClaimResponse: Def1_RetrieveLossClaimResponse =
+    Def1_RetrieveLossClaimResponse(
+      "2019-20",
+      TypeOfLoss.`self-employment`,
+      TypeOfClaim.`carry-forward`,
+      "XKIS00000000988",
+      Some(1),
+      Timestamp("2018-07-13T12:13:48.763Z")
+    )
+
+  val taxYear: TaxYear = TaxYear.fromMtd(retrieveLossClaimResponse.taxYearClaimedFor)
+
+  trait Test extends MockAmendLossClaimTypeConnector with MockRetrieveLossClaimConnector {
+    lazy val service = new AmendLossClaimTypeService(mockRetrieveLossClaimConnector, mockAmendLossClaimTypeConnector)
+
+    val amendRequest: Def1_AmendLossClaimTypeRequestData =
+      Def1_AmendLossClaimTypeRequestData(Nino(nino), ClaimId(claimId), requestBody)
+
+    val retrieveRequest: RetrieveLossClaimRequestData =
+      Def1_RetrieveLossClaimRequestData(Nino(nino), ClaimId(claimId))
+
   }
 
   "amend LossClaim" when {
 
     "valid data is passed" should {
       "return a successful response with the correct correlationId" in new Test {
-        MockAmendLossClaimTypeConnector
-          .amendLossClaimType(request)
-          .returns(Future.successful(Right(ResponseWrapper(correlationId, lossClaimResponse))))
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = retrieveRequest, isAmendRequest = true)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveLossClaimResponse))))
 
-        await(service.amendLossClaimType(request)) shouldBe Right(ResponseWrapper(correlationId, lossClaimResponse))
+        MockAmendLossClaimTypeConnector
+          .amendLossClaimType(amendRequest, taxYear)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, amendLossClaimResponse))))
+
+        await(service.amendLossClaimType(amendRequest)) shouldBe Right(ResponseWrapper(correlationId, amendLossClaimResponse))
       }
     }
 
     "return that wrapped error as-is" when {
-      "the connector returns an outbound error" in new Test {
+      "the retrieve connector returns an outbound error" in new Test {
         val someError: MtdError                                = MtdError("SOME_CODE", "some message", BAD_REQUEST)
         val downstreamResponse: ResponseWrapper[OutboundError] = ResponseWrapper(correlationId, OutboundError(someError))
 
-        MockAmendLossClaimTypeConnector.amendLossClaimType(request).returns(Future.successful(Left(downstreamResponse)))
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = retrieveRequest, isAmendRequest = true)
+          .returns(Future.successful(Left(downstreamResponse)))
 
-        await(service.amendLossClaimType(request)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
+        await(service.amendLossClaimType(amendRequest)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
+      }
+
+      "the amend connector returns an outbound error" in new Test {
+        val someError: MtdError                                = MtdError("SOME_CODE", "some message", BAD_REQUEST)
+        val downstreamResponse: ResponseWrapper[OutboundError] = ResponseWrapper(correlationId, OutboundError(someError))
+
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = retrieveRequest, isAmendRequest = true)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveLossClaimResponse))))
+
+        MockAmendLossClaimTypeConnector.amendLossClaimType(amendRequest, taxYear).returns(Future.successful(Left(downstreamResponse)))
+
+        await(service.amendLossClaimType(amendRequest)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
       }
     }
 
     "map errors according to spec" when {
-      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
-        s"a $downstreamErrorCode error is returned from the service" in new Test {
-          MockAmendLossClaimTypeConnector
-            .amendLossClaimType(request)
+      def serviceErrorFromRetrieveConnector(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service when the retrieve connector call fails" in new Test {
+          MockRetrieveLossClaimConnector
+            .retrieveLossClaim(request = retrieveRequest, isAmendRequest = true)
             .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
 
-          private val result = await(service.amendLossClaimType(request))
+          private val result = await(service.amendLossClaimType(amendRequest))
           result shouldBe Left(ErrorWrapper(correlationId, error))
         }
 
-      val errors: Seq[(String, MtdError)] = List(
+      def serviceErrorFromAmendConnector(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service when the amend connector call fails" in new Test {
+          MockRetrieveLossClaimConnector
+            .retrieveLossClaim(request = retrieveRequest, isAmendRequest = true)
+            .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveLossClaimResponse))))
+
+          MockAmendLossClaimTypeConnector
+            .amendLossClaimType(amendRequest, taxYear)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          private val result = await(service.amendLossClaimType(amendRequest))
+          result shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val retrieveErrors: Seq[(String, MtdError)] = List(
+        "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+        "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
+        "NOT_FOUND"                 -> NotFoundError,
+        "INVALID_CORRELATIONID"     -> InternalError,
+        "SERVER_ERROR"              -> InternalError,
+        "SERVICE_UNAVAILABLE"       -> InternalError,
+        "UNEXPECTED_ERROR"          -> InternalError
+      )
+
+      val amendErrors: Seq[(String, MtdError)] = List(
         "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
         "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
         "INVALID_PAYLOAD"           -> InternalError,
@@ -98,7 +163,8 @@ class AmendLossClaimTypeServiceSpec extends ServiceSpec {
         "UNEXPECTED_ERROR"          -> InternalError
       )
 
-      errors.foreach(args => (serviceError _).tupled(args))
+      retrieveErrors.foreach(args => (serviceErrorFromRetrieveConnector _).tupled(args))
+      amendErrors.foreach(args => (serviceErrorFromAmendConnector _).tupled(args))
 
     }
   }

--- a/test/v5/lossClaims/amendType/MockAmendLossClaimTypeConnector.scala
+++ b/test/v5/lossClaims/amendType/MockAmendLossClaimTypeConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package v5.lossClaims.amendType
 import shared.connectors.DownstreamOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.HeaderCarrier
 import v5.lossClaims.amendType.model.request.AmendLossClaimTypeRequestData
 import v5.lossClaims.amendType.model.response.AmendLossClaimTypeResponse
@@ -31,11 +32,11 @@ trait MockAmendLossClaimTypeConnector extends MockFactory {
 
   object MockAmendLossClaimTypeConnector {
 
-    def amendLossClaimType(request: AmendLossClaimTypeRequestData): CallHandler[Future[DownstreamOutcome[AmendLossClaimTypeResponse]]] = {
+    def amendLossClaimType(request: AmendLossClaimTypeRequestData,
+                           taxYear: TaxYear): CallHandler[Future[DownstreamOutcome[AmendLossClaimTypeResponse]]] =
       (mockAmendLossClaimTypeConnector
-        .amendLossClaimType(_: AmendLossClaimTypeRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
-        .expects(request, *, *, *)
-    }
+        .amendLossClaimType(_: AmendLossClaimTypeRequestData, _: TaxYear)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(request, taxYear, *, *, *)
 
   }
 

--- a/test/v5/lossClaims/delete/DeleteLossClaimConnectorSpec.scala
+++ b/test/v5/lossClaims/delete/DeleteLossClaimConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package v5.lossClaims.delete
 
 import play.api.Configuration
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
-import shared.models.domain.Nino
+import shared.models.domain.{Nino, TaxYear}
 import shared.models.outcomes.ResponseWrapper
 import v5.lossClaims.common.models.ClaimId
 import v5.lossClaims.delete.def1.model.request.Def1_DeleteLossClaimRequestData
@@ -27,8 +27,9 @@ import scala.concurrent.Future
 
 class DeleteLossClaimConnectorSpec extends ConnectorSpec {
 
-  private val nino    = Nino("AA123456A")
-  private val claimId = ClaimId("AAZZ1234567890ag")
+  private val nino              = Nino("AA123456A")
+  private val claimId           = ClaimId("AAZZ1234567890ag")
+  private val taxYearClaimedFor = TaxYear.fromMtd("2019-20")
 
   "delete LossClaim" when {
     "given a valid request" when {
@@ -41,7 +42,7 @@ class DeleteLossClaimConnectorSpec extends ConnectorSpec {
           willDelete(s"$baseUrl/income-tax/claims-for-relief/$nino/$claimId")
             .returning(Future.successful(expected))
 
-          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request))
+          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request, taxYearClaimedFor))
           result shouldBe expected
         }
       }
@@ -51,10 +52,10 @@ class DeleteLossClaimConnectorSpec extends ConnectorSpec {
           MockedSharedAppConfig.featureSwitchConfig returns Configuration("des_hip_migration_1509.enabled" -> true)
           val expected: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
 
-          willDelete(s"$baseUrl/itsa/income-tax/v1/claims-for-relief/$nino/$claimId")
+          willDelete(s"$baseUrl/itsa/income-tax/v1/claims-for-relief/$nino/19-20/$claimId")
             .returning(Future.successful(expected))
 
-          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request))
+          val result: DownstreamOutcome[Unit] = await(connector.deleteLossClaim(request, taxYearClaimedFor))
           result shouldBe expected
         }
       }

--- a/test/v5/lossClaims/delete/DeleteLossClaimServiceSpec.scala
+++ b/test/v5/lossClaims/delete/DeleteLossClaimServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,17 @@
 package v5.lossClaims.delete
 
 import common.errors.ClaimIdFormatError
-import shared.models.domain.Nino
+import shared.models.domain.{Nino, TaxYear, Timestamp}
 import shared.models.errors._
 import shared.models.outcomes.ResponseWrapper
 import shared.services.ServiceSpec
-import v5.lossClaims.common.models.ClaimId
+import v5.lossClaims.common.models.{ClaimId, TypeOfClaim, TypeOfLoss}
 import v5.lossClaims.delete.def1.model.request.Def1_DeleteLossClaimRequestData
 import v5.lossClaims.delete.model.request.DeleteLossClaimRequestData
+import v5.lossClaims.retrieve.MockRetrieveLossClaimConnector
+import v5.lossClaims.retrieve.def1.model.request.Def1_RetrieveLossClaimRequestData
+import v5.lossClaims.retrieve.def1.model.response.Def1_RetrieveLossClaimResponse
+import v5.lossClaims.retrieve.model.request.RetrieveLossClaimRequestData
 
 import scala.concurrent.Future
 
@@ -32,11 +36,24 @@ class DeleteLossClaimServiceSpec extends ServiceSpec {
   val nino: String    = "AA123456A"
   val claimId: String = "AAZZ1234567890a"
 
-  trait Test extends MockDeleteLossClaimConnector {
-    lazy val service = new DeleteLossClaimService(connector)
+  val retrieveLossClaimResponse: Def1_RetrieveLossClaimResponse =
+    Def1_RetrieveLossClaimResponse(
+      "2019-20",
+      TypeOfLoss.`self-employment`,
+      TypeOfClaim.`carry-forward`,
+      "XKIS00000000988",
+      Some(1),
+      Timestamp("2018-07-13T12:13:48.763Z")
+    )
+
+  val taxYear: TaxYear = TaxYear.fromMtd(retrieveLossClaimResponse.taxYearClaimedFor)
+
+  trait Test extends MockDeleteLossClaimConnector with MockRetrieveLossClaimConnector {
+    lazy val service = new DeleteLossClaimService(mockRetrieveLossClaimConnector, mockDeleteLossClaimConnector)
   }
 
-  lazy val request: DeleteLossClaimRequestData = Def1_DeleteLossClaimRequestData(Nino(nino), ClaimId(claimId))
+  lazy val deleteRequest: DeleteLossClaimRequestData     = Def1_DeleteLossClaimRequestData(Nino(nino), ClaimId(claimId))
+  lazy val retrieveRequest: RetrieveLossClaimRequestData = Def1_RetrieveLossClaimRequestData(Nino(nino), ClaimId(claimId))
 
   "Delete Loss Claim" should {
     "return a right" when {
@@ -45,38 +62,81 @@ class DeleteLossClaimServiceSpec extends ServiceSpec {
         val downstreamResponse: ResponseWrapper[Unit] = ResponseWrapper(correlationId, ())
         val expected: ResponseWrapper[Unit]           = ResponseWrapper(correlationId, ())
 
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = retrieveRequest, isAmendRequest = false)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveLossClaimResponse))))
+
         MockDeleteLossClaimConnector
-          .deleteLossClaim(request)
+          .deleteLossClaim(deleteRequest, taxYear)
           .returns(Future.successful(Right(downstreamResponse)))
 
-        await(service.deleteLossClaim(request)) shouldBe Right(expected)
+        await(service.deleteLossClaim(deleteRequest)) shouldBe Right(expected)
 
       }
     }
 
     "return that wrapped error as-is" when {
-      "the connector returns an outbound error" in new Test {
+      "the retrieve connector returns an outbound error" in new Test {
         val someError: MtdError                                = MtdError("SOME_CODE", "some message", BAD_REQUEST)
         val downstreamResponse: ResponseWrapper[OutboundError] = ResponseWrapper(correlationId, OutboundError(someError))
-        MockDeleteLossClaimConnector.deleteLossClaim(request).returns(Future.successful(Left(downstreamResponse)))
 
-        await(service.deleteLossClaim(request)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = retrieveRequest, isAmendRequest = false)
+          .returns(Future.successful(Left(downstreamResponse)))
+
+        await(service.deleteLossClaim(deleteRequest)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
+      }
+
+      "the delete connector returns an outbound error" in new Test {
+        val someError: MtdError                                = MtdError("SOME_CODE", "some message", BAD_REQUEST)
+        val downstreamResponse: ResponseWrapper[OutboundError] = ResponseWrapper(correlationId, OutboundError(someError))
+
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = retrieveRequest, isAmendRequest = false)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveLossClaimResponse))))
+
+        MockDeleteLossClaimConnector.deleteLossClaim(deleteRequest, taxYear).returns(Future.successful(Left(downstreamResponse)))
+
+        await(service.deleteLossClaim(deleteRequest)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
       }
     }
 
     "map errors according to spec" when {
-      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
-        s"a $downstreamErrorCode error is returned from the service" in new Test {
-
-          MockDeleteLossClaimConnector
-            .deleteLossClaim(request)
+      def serviceErrorFromRetrieveConnector(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service when the retrieve connector call fails" in new Test {
+          MockRetrieveLossClaimConnector
+            .retrieveLossClaim(request = retrieveRequest, isAmendRequest = false)
             .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
 
-          private val result = await(service.deleteLossClaim(request))
+          private val result = await(service.deleteLossClaim(deleteRequest))
           result shouldBe Left(ErrorWrapper(correlationId, error))
         }
 
-      val errors: Seq[(String, MtdError)] = List(
+      def serviceErrorFromDeleteConnector(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service when the delete connector call fails" in new Test {
+          MockRetrieveLossClaimConnector
+            .retrieveLossClaim(request = retrieveRequest, isAmendRequest = false)
+            .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveLossClaimResponse))))
+
+          MockDeleteLossClaimConnector
+            .deleteLossClaim(deleteRequest, taxYear)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          private val result = await(service.deleteLossClaim(deleteRequest))
+          result shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val retrieveErrors: Seq[(String, MtdError)] = List(
+        "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+        "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
+        "NOT_FOUND"                 -> NotFoundError,
+        "INVALID_CORRELATIONID"     -> InternalError,
+        "SERVER_ERROR"              -> InternalError,
+        "SERVICE_UNAVAILABLE"       -> InternalError,
+        "UNEXPECTED_ERROR"          -> InternalError
+      )
+
+      val deleteErrors: Seq[(String, MtdError)] = List(
         "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
         "INVALID_CLAIM_ID"          -> ClaimIdFormatError,
         "NOT_FOUND"                 -> NotFoundError,
@@ -85,7 +145,8 @@ class DeleteLossClaimServiceSpec extends ServiceSpec {
         "UNEXPECTED_ERROR"          -> InternalError
       )
 
-      errors.foreach(args => (serviceError _).tupled(args))
+      retrieveErrors.foreach(args => (serviceErrorFromRetrieveConnector _).tupled(args))
+      deleteErrors.foreach(args => (serviceErrorFromDeleteConnector _).tupled(args))
     }
   }
 

--- a/test/v5/lossClaims/delete/MockDeleteLossClaimConnector.scala
+++ b/test/v5/lossClaims/delete/MockDeleteLossClaimConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,21 @@ package v5.lossClaims.delete
 import shared.connectors.DownstreamOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
+import shared.models.domain.TaxYear
 import uk.gov.hmrc.http.HeaderCarrier
 import v5.lossClaims.delete.model.request.DeleteLossClaimRequestData
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait MockDeleteLossClaimConnector extends MockFactory {
-  val connector: DeleteLossClaimConnector = mock[DeleteLossClaimConnector]
+  val mockDeleteLossClaimConnector: DeleteLossClaimConnector = mock[DeleteLossClaimConnector]
 
   object MockDeleteLossClaimConnector {
 
-    def deleteLossClaim(deleteLossClaimRequest: DeleteLossClaimRequestData): CallHandler[Future[DownstreamOutcome[Unit]]] = {
-      (connector
-        .deleteLossClaim(_: DeleteLossClaimRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
-        .expects(deleteLossClaimRequest, *, *, *)
-    }
+    def deleteLossClaim(deleteLossClaimRequest: DeleteLossClaimRequestData, taxYear: TaxYear): CallHandler[Future[DownstreamOutcome[Unit]]] =
+      (mockDeleteLossClaimConnector
+        .deleteLossClaim(_: DeleteLossClaimRequestData, _: TaxYear)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(deleteLossClaimRequest, taxYear, *, *, *)
 
   }
 

--- a/test/v5/lossClaims/retrieve/MockRetrieveLossClaimConnector.scala
+++ b/test/v5/lossClaims/retrieve/MockRetrieveLossClaimConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,15 +26,15 @@ import v5.lossClaims.retrieve.model.response.RetrieveLossClaimResponse
 import scala.concurrent.{ExecutionContext, Future}
 
 trait MockRetrieveLossClaimConnector extends MockFactory {
-  val connector: RetrieveLossClaimConnector = mock[RetrieveLossClaimConnector]
+  val mockRetrieveLossClaimConnector: RetrieveLossClaimConnector = mock[RetrieveLossClaimConnector]
 
   object MockRetrieveLossClaimConnector {
 
-    def retrieveLossClaim(request: RetrieveLossClaimRequestData): CallHandler[Future[DownstreamOutcome[RetrieveLossClaimResponse]]] = {
-      (connector
-        .retrieveLossClaim(_: RetrieveLossClaimRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
-        .expects(request, *, *, *)
-    }
+    def retrieveLossClaim(request: RetrieveLossClaimRequestData,
+                          isAmendRequest: Boolean): CallHandler[Future[DownstreamOutcome[RetrieveLossClaimResponse]]] =
+      (mockRetrieveLossClaimConnector
+        .retrieveLossClaim(_: RetrieveLossClaimRequestData, _: Boolean)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(request, isAmendRequest, *, *, *)
 
   }
 

--- a/test/v5/lossClaims/retrieve/RetrieveLossClaimConnectorSpec.scala
+++ b/test/v5/lossClaims/retrieve/RetrieveLossClaimConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package v5.lossClaims.retrieve
 
+import play.api.Configuration
 import shared.connectors.{ConnectorSpec, DownstreamOutcome}
 import shared.models.domain.{Nino, Timestamp}
 import shared.models.outcomes.ResponseWrapper
@@ -43,20 +44,31 @@ class RetrieveLossClaimConnectorSpec extends ConnectorSpec {
       Timestamp("2018-07-13T12:13:48.763Z")
     )
 
-    val request = Def1_RetrieveLossClaimRequestData(Nino(nino), ClaimId(claimId))
-
-    def retrieveLossClaimResult(connector: RetrieveLossClaimConnector): DownstreamOutcome[RetrieveLossClaimResponse] =
-      await(connector.retrieveLossClaim(request))
+    val request: Def1_RetrieveLossClaimRequestData = Def1_RetrieveLossClaimRequestData(Nino(nino), ClaimId(claimId))
 
     "return a successful response and correlationId" when {
-      "provided with a valid request" in new IfsTest with Test {
-        private val expected = Left(ResponseWrapper(correlationId, retrieveResponse))
+      List(
+        (false, false, None),
+        (false, true, None),
+        (true, false, None),
+        (true, true, Some("AMEND_LOSS_CLAIM"))
+      ).foreach { case (isAmendRequestValue, passIntentHeaderFlag, intentValue) =>
+        s"provided with a valid request, isAmendRequest is $isAmendRequestValue and passIntentHeader is $passIntentHeaderFlag" in new IfsTest
+          with Test {
+          override def intent: Option[String] = intentValue
 
-        willGet(s"$baseUrl/income-tax/claims-for-relief/$nino/$claimId")
-          .returning(Future.successful(expected))
+          private val expected = Left(ResponseWrapper(correlationId, retrieveResponse))
 
-        val result: DownstreamOutcome[RetrieveLossClaimResponse] = retrieveLossClaimResult(connector)
-        result shouldBe expected
+          MockedSharedAppConfig.featureSwitchConfig returns Configuration("passIntentHeader.enabled" -> passIntentHeaderFlag)
+
+          willGet(s"$baseUrl/income-tax/claims-for-relief/$nino/$claimId")
+            .returning(Future.successful(expected))
+
+          val result: DownstreamOutcome[RetrieveLossClaimResponse] =
+            await(connector.retrieveLossClaim(request = request, isAmendRequest = isAmendRequestValue))
+
+          result shouldBe expected
+        }
       }
     }
   }

--- a/test/v5/lossClaims/retrieve/RetrieveLossClaimServiceSpec.scala
+++ b/test/v5/lossClaims/retrieve/RetrieveLossClaimServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
   val claimId: String = "AAZZ1234567890a"
 
   trait Test extends MockRetrieveLossClaimConnector {
-    lazy val service = new RetrieveLossClaimService(connector)
+    lazy val service = new RetrieveLossClaimService(mockRetrieveLossClaimConnector)
   }
 
   lazy val request: RetrieveLossClaimRequestData = Def1_RetrieveLossClaimRequestData(Nino(nino), ClaimId(claimId))
@@ -55,7 +55,9 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
               Timestamp("2018-07-13T12:13:48.763Z")
             )
           )
-        MockRetrieveLossClaimConnector.retrieveLossClaim(request).returns(Future.successful(Right(downstreamResponse)))
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = request, isAmendRequest = false)
+          .returns(Future.successful(Right(downstreamResponse)))
 
         await(service.retrieveLossClaim(request)) shouldBe Right(downstreamResponse)
       }
@@ -65,7 +67,9 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
       "the connector returns an outbound error" in new Test {
         val someError: MtdError                                = MtdError("SOME_CODE", "some message", BAD_REQUEST)
         val downstreamResponse: ResponseWrapper[OutboundError] = ResponseWrapper(correlationId, OutboundError(someError))
-        MockRetrieveLossClaimConnector.retrieveLossClaim(request).returns(Future.successful(Left(downstreamResponse)))
+        MockRetrieveLossClaimConnector
+          .retrieveLossClaim(request = request, isAmendRequest = false)
+          .returns(Future.successful(Left(downstreamResponse)))
 
         await(service.retrieveLossClaim(request)) shouldBe Left(ErrorWrapper(correlationId, someError, None))
       }
@@ -76,7 +80,7 @@ class RetrieveLossClaimServiceSpec extends ServiceSpec {
         s"a $downstreamErrorCode error is returned from the service" in new Test {
 
           MockRetrieveLossClaimConnector
-            .retrieveLossClaim(request)
+            .retrieveLossClaim(request = request, isAmendRequest = false)
             .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
 
           private val result = await(service.retrieveLossClaim(request))


### PR DESCRIPTION
This is only for amend loss claims V4 and V5. BF losses will be easier as we will default the tax year. The changes will be rolled out to delete loss claims once reviewed. Still need to review and maybe cleanup names etc. but it should work as expected.