### PR TITLE
Configure temporal validation for taxYearBroughtForwardFrom in request body for create BF Loss to relax RuleTaxYearNotEndedError validation in QA

### DIFF
--- a/app/v6/bfLosses/create/CreateBFLossValidatorFactory.scala
+++ b/app/v6/bfLosses/create/CreateBFLossValidatorFactory.scala
@@ -27,10 +27,11 @@ import javax.inject.Singleton
 @Singleton
 class CreateBFLossValidatorFactory {
 
-  def validator(nino: String, taxYear: String, body: JsValue): Validator[CreateBFLossRequestData] = {
-    val schema = CreateBFLossSchema.schema
+  def validator(nino: String, taxYear: String, body: JsValue, temporalValidationEnabled: Boolean): Validator[CreateBFLossRequestData] = {
+    val schema: CreateBFLossSchema = CreateBFLossSchema.schema
+
     schema match {
-      case Def1 => new Def1_CreateBFLossValidator(nino, taxYear, body)
+      case Def1 => new Def1_CreateBFLossValidator(nino, taxYear, body, temporalValidationEnabled)
     }
   }
 

--- a/it/test/v6/bfLosses/create/def1/Def1_CreateBFLossControllerIfsISpec.scala
+++ b/it/test/v6/bfLosses/create/def1/Def1_CreateBFLossControllerIfsISpec.scala
@@ -58,7 +58,7 @@ class Def1_CreateBFLossControllerIfsISpec extends IntegrationBaseSpec with JsonE
         .withHttpHeaders(
           (ACCEPT, "application/vnd.hmrc.6.0+json"),
           (AUTHORIZATION, "Bearer 123"),
-          ("suspend-temporal-validations", "true")
+          ("suspend-temporal-validations", "false")
         )
     }
 

--- a/test/v6/bfLosses/create/CreateBFLossValidatorFactorySpec.scala
+++ b/test/v6/bfLosses/create/CreateBFLossValidatorFactorySpec.scala
@@ -16,35 +16,38 @@
 
 package v6.bfLosses.create
 
-import shared.models.utils.JsonErrorValidators
 import play.api.libs.json.{JsValue, Json}
+import shared.controllers.validators.Validator
 import shared.utils.UnitSpec
 import v6.bfLosses.create.def1.Def1_CreateBFLossValidator
+import v6.bfLosses.create.model.request.CreateBFLossRequestData
 
-class CreateBFLossValidatorFactorySpec extends UnitSpec with JsonErrorValidators {
+class CreateBFLossValidatorFactorySpec extends UnitSpec {
 
-  private val validNino       = "AA123456A"
-  private val validTaxYear    = "2025-26"
-  private val validLossAmount = 1000
-
-  def requestBodyJson(lossAmount: BigDecimal = validLossAmount): JsValue = Json.parse(
-    s"""
-       |{
-       |  "lossAmount": "$lossAmount"
-       |}
-     """.stripMargin
+  private val requestBodyJson: JsValue = Json.parse(
+    """
+      |{
+      |  "typeOfLoss": "self-employment",
+      |  "businessId": "XAIS01234567890",
+      |  "taxYearBroughtForwardFrom": "2024-25",
+      |  "lossAmount": 1000
+      |}
+    """.stripMargin
   )
 
-  private val validRequestBody = requestBodyJson()
+  private val validatorFactory: CreateBFLossValidatorFactory = new CreateBFLossValidatorFactory
 
-  private val validatorFactory = new CreateBFLossValidatorFactory
+  "validator()" when {
+    "given any tax year" should {
+      "return the Validator for schema definition 1" in {
+        val result: Validator[CreateBFLossRequestData] = validatorFactory.validator(
+          nino = "AA123456A",
+          taxYear = "2025-26",
+          body = requestBodyJson,
+          temporalValidationEnabled = true
+        )
 
-  "running a validation" should {
-    "return the parsed domain object" when {
-      "given a valid request" in {
-        val result = validatorFactory.validator(validNino, validTaxYear, validRequestBody)
         result shouldBe a[Def1_CreateBFLossValidator]
-
       }
     }
 

--- a/test/v6/bfLosses/create/MockCreateBFLossValidatorFactory.scala
+++ b/test/v6/bfLosses/create/MockCreateBFLossValidatorFactory.scala
@@ -24,7 +24,6 @@ import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.TestSuite
 import play.api.libs.json.JsValue
-import v6.bfLosses.create.CreateBFLossValidatorFactory
 import v6.bfLosses.create.model.request.CreateBFLossRequestData
 
 trait MockCreateBFLossValidatorFactory extends TestSuite with MockFactory {
@@ -35,8 +34,8 @@ trait MockCreateBFLossValidatorFactory extends TestSuite with MockFactory {
 
     def expectValidator(): CallHandler[Validator[CreateBFLossRequestData]] =
       (mockCreateBFLossValidatorFactory
-        .validator(_: String, _: String, _: JsValue))
-        .expects(*, *, *)
+        .validator(_: String, _: String, _: JsValue, _: Boolean))
+        .expects(*, *, *, *)
 
   }
 


### PR DESCRIPTION
Also, I removed the duplicated tax year validations of `taxYearBroughtForwardFrom` brought in via ResolveIncompleteTaxYear and in the ITs focused changes on the HIPISpec as the IFS one will be removed.